### PR TITLE
code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of conduct
+
+Everyone is invited to participate in Mapbox’s open source projects and public discussions: we want to create a welcoming and friendly environment. Harassment of participants or other unethical and unprofessional behavior will not be tolerated in our spaces. The [Contributor Covenant](http://contributor-covenant.org) applies to all projects under the Mapbox organization and we ask that you please read [the full text](http://contributor-covenant.org/version/1/2/0/).
+
+You can learn more about our open source philosophy on [mapbox.com](https://www.mapbox.com/about/open/).


### PR DESCRIPTION
Adds CODE_OF_CONDUCT.md with the standard Mapbox covenant, similar to vtshaver: https://github.com/mapbox/vtshaver/blob/master/CODE_OF_CONDUCT.md

cc @millzpaugh 