### PR TITLE
Erroneous output if api-tilesets endpoint fails 

### DIFF
--- a/tilesets/cli.py
+++ b/tilesets/cli.py
@@ -99,10 +99,10 @@ def upload(ctx, tileset, files, no_validation, token=None):
         r = requests.post(url)
         if r.status_code == 200:
             uploader.upload(f, r.json())
+            click.echo(f'Done staging files. You can publish these to a tileset with `tilesets publish {tileset}`')
         else:
             utils.print_response(r.text)
 
-    click.echo(f'Done staging files. You can publish these to a tileset with `tilesets publish {tileset}`')
 
 
 @cli.command('publish')


### PR DESCRIPTION
Fixes the scenario where we have a success + failure message. 

![Screen Shot 2019-07-26 at 1 52 22 PM](https://user-images.githubusercontent.com/4648295/61980969-1cdd9f00-afad-11e9-9230-41c1b9fa6665.png)
