### PR TITLE
Get tokens from the environment when commands are invoked

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(scope="function")
+def token_environ(monkeypatch):
+    monkeypatch.setenv("MAPBOX_ACCESS_TOKEN", "fake-token")
+    monkeypatch.setenv("MapboxAccessToken", "test-token")

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -1,11 +1,9 @@
-from click.testing import CliRunner
 from unittest import mock
 import json
 
-# have to set environment variables before importing library
-# since they are used in __init__
-mock_env=mock.patch.dict('os.environ', {'MAPBOX_ACCESS_TOKEN': 'fake-token', 'MapboxAccessToken': 'test-token'})
-mock_env.start()
+from click.testing import CliRunner
+import pytest
+
 from tilesets.cli import create
 
 
@@ -16,6 +14,7 @@ class MockResponse():
         return self
 
 
+@pytest.mark.usefixtures("token_environ")
 def test_cli_create_missing_recipe():
     runner = CliRunner()
     # missing --recipe option
@@ -24,6 +23,7 @@ def test_cli_create_missing_recipe():
     assert 'Missing option "--recipe"' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 def test_cli_create_missing_name():
     runner = CliRunner()
     # missing --name option
@@ -32,6 +32,7 @@ def test_cli_create_missing_name():
     assert 'Missing option "--name"' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.post')
 def test_cli_create_success(mock_request_post):
     runner = CliRunner()
@@ -43,6 +44,7 @@ def test_cli_create_success(mock_request_post):
     assert '{\n  "message": "mock message"\n}\n' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.post')
 def test_cli_create_success_description(mock_request_post):
     runner = CliRunner()
@@ -62,6 +64,7 @@ def test_cli_create_success_description(mock_request_post):
     assert '{\n  "message": "mock message with description"\n}\n' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.post')
 def test_cli_create_private_invalid(mock_request_post):
     runner = CliRunner()
@@ -80,6 +83,7 @@ def test_cli_create_private_invalid(mock_request_post):
     assert 'Invalid value for "--privacy" / "-p": invalid choice: invalid-privacy-value. (choose from public, private)' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.post')
 def test_cli_use_token_flag(mock_request_post):
     runner = CliRunner()
@@ -89,6 +93,3 @@ def test_cli_use_token_flag(mock_request_post):
     assert result.exit_code == 0
     mock_request_post.assert_called_with('https://api.mapbox.com/tilesets/v1/test.id?access_token=flag-token', json={'name': 'test name', 'description': '', 'recipe': {'minzoom': 0, 'maxzoom': 10, 'layer_name': 'test_layer'}})
     assert '{\n  "message": "mock message"\n}\n' in result.output
-
-
-mock_env.stop()

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -1,10 +1,8 @@
-from click.testing import CliRunner
 from unittest import mock
 
-# have to set environment variables before importing library
-# since they are used in __init__
-mock_env=mock.patch.dict('os.environ', {'MAPBOX_ACCESS_TOKEN': 'fake-token', 'MapboxAccessToken': 'test-token'})
-mock_env.start()
+from click.testing import CliRunner
+import pytest
+
 from tilesets.cli import jobs, job
 
 
@@ -15,6 +13,7 @@ class MockResponse():
     def MockResponse(self):
         return self
 
+
 class MockResponseError():
     def __init__(self, mock_text):
         self.text = mock_text
@@ -22,6 +21,8 @@ class MockResponseError():
     def MockResponse(self):
         return self
 
+
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_job(mock_request_get):
     runner = CliRunner()
@@ -33,6 +34,8 @@ def test_cli_job(mock_request_get):
     assert result.exit_code == 0
     assert '{\n  "message": "mock message"\n}\n' in result.output
 
+
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_job_error(mock_request_get):
     runner = CliRunner()
@@ -44,9 +47,11 @@ def test_cli_job_error(mock_request_get):
     assert result.exit_code == 0
     assert '{\n  "message": "mock error message"\n}\n' in result.output
 
-# test jobs + stage endpoint
+
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_jobs_and_stage(mock_request_get):
+    """test jobs + stage endpoint"""
     runner = CliRunner()
 
     # sends expected request
@@ -56,9 +61,11 @@ def test_cli_jobs_and_stage(mock_request_get):
     assert result.exit_code == 0
     assert '{\n  "message": "mock message"\n}\n' in result.output
 
-# test job endpoint
+
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_single_job(mock_request_get):
+    """test job endpoint"""
     runner = CliRunner()
 
     # sends expected request
@@ -67,6 +74,3 @@ def test_cli_single_job(mock_request_get):
     mock_request_get.assert_called_with('https://api.mapbox.com/tilesets/v1/test.id/jobs/job_id?access_token=fake-token')
     assert result.exit_code == 0
     assert '{\n  "message": "mock message"\n}\n' in result.output
-
-
-mock_env.stop()

--- a/tests/test_cli_publish.py
+++ b/tests/test_cli_publish.py
@@ -1,10 +1,8 @@
 from click.testing import CliRunner
 from unittest import mock
 
-# have to set environment variables before importing library
-# since they are used in __init__
-mock_env=mock.patch.dict('os.environ', {'MAPBOX_ACCESS_TOKEN': 'fake-token', 'MapboxAccessToken': 'test-token'})
-mock_env.start()
+import pytest
+
 from tilesets.cli import publish
 
 
@@ -16,6 +14,7 @@ class MockResponse():
         return self
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.post')
 def test_cli_publish(mock_request_post):
     runner = CliRunner()
@@ -28,6 +27,7 @@ def test_cli_publish(mock_request_post):
     assert 'You can view the status of your tileset with the `tilesets status test.id` command.' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.post')
 def test_cli_publish_use_token_flag(mock_request_post):
     runner = CliRunner()
@@ -37,6 +37,3 @@ def test_cli_publish_use_token_flag(mock_request_post):
     mock_request_post.assert_called_with('https://api.mapbox.com/tilesets/v1/test.id/publish?access_token=flag-token')
     assert result.exit_code == 0
     assert 'You can view the status of your tileset with the `tilesets status test.id` command.' in result.output
-
-
-mock_env.stop()

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -2,10 +2,8 @@ from click.testing import CliRunner
 from unittest import mock
 import json
 
-# have to set environment variables before importing library
-# since they are used in __init__
-mock_env=mock.patch.dict('os.environ', {'MAPBOX_ACCESS_TOKEN': 'fake-token', 'MapboxAccessToken': 'test-token'})
-mock_env.start()
+import pytest
+
 from tilesets.cli import (
     add_source,
     view_source,
@@ -24,6 +22,8 @@ class MockResponse():
     def json(self):
         return json.loads(self.text)
 
+
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.post')
 def test_cli_add_source(mock_request_post):
     mock_request_post.return_value = MockResponse('{"id":"mapbox://tileset-source/test-user/hello-world"}', 200)
@@ -35,6 +35,7 @@ def test_cli_add_source(mock_request_post):
     assert '{\n  "id": "mapbox://tileset-source/test-user/hello-world"\n}\n' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_view_source(mock_request_get):
     mock_request_get.return_value = MockResponse('{"id":"mapbox://tileset-source/test-user/hello-world"}', 200)
@@ -44,6 +45,7 @@ def test_cli_view_source(mock_request_get):
     assert result.output == '{\n  "id": "mapbox://tileset-source/test-user/hello-world"\n}\n'
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.delete')
 def test_cli_delete_source(mock_request_delete):
     mock_request_delete.return_value = MockResponse('', 201)
@@ -53,6 +55,7 @@ def test_cli_delete_source(mock_request_delete):
     assert result.output == 'Source deleted.\n'
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_view_source(mock_request_get):
     mock_request_get.return_value = MockResponse(
@@ -67,6 +70,7 @@ def test_cli_view_source(mock_request_get):
     assert "mapbox://tileset-source/test-user/hola-mundo" in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 def test_cli_validate_source():
     runner = CliRunner()
     result = runner.invoke(validate_source, ['tests/fixtures/valid.ldgeojson'])

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,10 +1,8 @@
 from click.testing import CliRunner
 from unittest import mock
 
-# have to set environment variables before importing library
-# since they are used in __init__
-mock_env=mock.patch.dict('os.environ', {'MAPBOX_ACCESS_TOKEN': 'fake-token', 'MapboxAccessToken': 'test-token'})
-mock_env.start()
+import pytest
+
 from tilesets.cli import status
 
 
@@ -16,6 +14,7 @@ class MockResponse():
         return self
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_status(mock_request_get):
     runner = CliRunner()
@@ -28,6 +27,7 @@ def test_cli_status(mock_request_get):
     assert '{\n  "message": "mock message"\n}\n' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_status_use_token_flag(mock_request_get):
     runner = CliRunner()
@@ -37,6 +37,3 @@ def test_cli_status_use_token_flag(mock_request_get):
     mock_request_get.assert_called_with('https://api.mapbox.com/tilesets/v1/test.id/status?access_token=flag-token')
     assert result.exit_code == 0
     assert '{\n  "message": "mock message"\n}\n' in result.output
-
-
-mock_env.stop()

--- a/tests/test_cli_update_recipe.py
+++ b/tests/test_cli_update_recipe.py
@@ -1,10 +1,7 @@
 from click.testing import CliRunner
 from unittest import mock
+import pytest
 
-# have to set environment variables before importing library
-# since they are used in __init__
-mock_env=mock.patch.dict('os.environ', {'MAPBOX_ACCESS_TOKEN': 'fake-token', 'MapboxAccessToken': 'test-token'})
-mock_env.start()
 from tilesets.cli import update_recipe
 
 
@@ -15,6 +12,7 @@ class MockResponse():
         return self
 
 
+@pytest.mark.usefixtures("token_environ")
 def test_cli_update_recipe_no_recipe():
     runner = CliRunner()
     result = runner.invoke(update_recipe, ['test.id', 'does/not/exist/recipe.json'])
@@ -22,6 +20,7 @@ def test_cli_update_recipe_no_recipe():
     assert 'Path "does/not/exist/recipe.json" does not exist' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.patch')
 def test_cli_update_recipe(mock_request_patch):
     runner = CliRunner()
@@ -37,6 +36,7 @@ def test_cli_update_recipe(mock_request_patch):
     assert 'Updated recipe.' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.patch')
 def test_cli_update_recipe(mock_request_patch):
     runner = CliRunner()
@@ -49,6 +49,3 @@ def test_cli_update_recipe(mock_request_patch):
     )
     assert result.exit_code == 0
     assert 'Updated recipe.' in result.output
-
-
-mock_env.stop()

--- a/tests/test_cli_validate_recipe.py
+++ b/tests/test_cli_validate_recipe.py
@@ -1,10 +1,7 @@
 from click.testing import CliRunner
 from unittest import mock
+import pytest
 
-# have to set environment variables before importing library
-# since they are used in __init__
-mock_env=mock.patch.dict('os.environ', {'MAPBOX_ACCESS_TOKEN': 'fake-token', 'MapboxAccessToken': 'test-token'})
-mock_env.start()
 from tilesets.cli import validate_recipe
 
 
@@ -16,6 +13,7 @@ class MockResponse():
         return self
 
 
+@pytest.mark.usefixtures("token_environ")
 def test_cli_validate_recipe_no_recipe():
     runner = CliRunner()
     result = runner.invoke(validate_recipe, ['does/not/exist/recipe.json'])
@@ -23,6 +21,7 @@ def test_cli_validate_recipe_no_recipe():
     assert 'Path "does/not/exist/recipe.json" does not exist' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.put')
 def test_cli_validate_recipe(mock_request_put):
     runner = CliRunner()
@@ -38,6 +37,7 @@ def test_cli_validate_recipe(mock_request_put):
     assert '{\n  "message": "mock message"\n}\n' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.put')
 def test_cli_validate_recipe_use_token_flag(mock_request_put):
     runner = CliRunner()
@@ -50,6 +50,3 @@ def test_cli_validate_recipe_use_token_flag(mock_request_put):
     )
     assert result.exit_code == 0
     assert '{\n  "message": "mock message"\n}\n' in result.output
-
-
-mock_env.stop()

--- a/tests/test_cli_view_recipe.py
+++ b/tests/test_cli_view_recipe.py
@@ -1,10 +1,7 @@
 from click.testing import CliRunner
 from unittest import mock
+import pytest
 
-# have to set environment variables before importing library
-# since they are used in __init__
-mock_env=mock.patch.dict('os.environ', {'MAPBOX_ACCESS_TOKEN': 'fake-token', 'MapboxAccessToken': 'test-token'})
-mock_env.start()
 from tilesets.cli import view_recipe
 
 
@@ -16,6 +13,7 @@ class MockResponse():
         return self
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_view_recipe(mock_request_get):
     runner = CliRunner()
@@ -30,6 +28,7 @@ def test_cli_view_recipe(mock_request_get):
     assert '{\n  "fake": "recipe_data"\n}\n' in result.output
 
 
+@pytest.mark.usefixtures("token_environ")
 @mock.patch('requests.get')
 def test_cli_view_recipe_use_token_flag(mock_request_get):
     runner = CliRunner()
@@ -41,6 +40,3 @@ def test_cli_view_recipe_use_token_flag(mock_request_get):
     )
     assert result.exit_code == 0
     assert '{\n  "fake": "recipe_data"\n}\n' in result.output
-
-
-mock_env.stop()

--- a/tilesets/__init__.py
+++ b/tilesets/__init__.py
@@ -1,10 +1,3 @@
-# tilesets-cli
-
-import os
+"""tilesets package"""
 
 __version__ = '0.1.0'
-
-MAPBOX_API = (os.environ.get('MAPBOX_API') or
-              'https://api.mapbox.com')
-MAPBOX_TOKEN = (os.environ.get('MAPBOX_ACCESS_TOKEN') or
-                os.environ.get('MapboxAccessToken'))


### PR DESCRIPTION
I glanced at the tests while working on #9 and noticed a minor race condition. This PR eliminates the race condition and makes testing easier. It allows the tileset module to be imported in any order you want within the tests, just like in normal code.

This PR also uses a pytest fixture to set tokens in the environment for individual tests. They are unset at the end, so this should prevent a few categories of future testing bugs.

Hope you find this useful @mapsam.