### PR TITLE
Update readme to clarify how to update a tileset

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Flags:
 
 ### publish
 
-Queues a tiling _job_ using the recipe provided. Use to publish a new tileset or updating an existing one. Returns a job ID for progress tracking.
+Queues a tiling _job_ using the recipe provided. Use to publish a new tileset or update an existing one. Returns a job ID for progress tracking.
 
 ```
 tilesets publish <tileset_id>

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Flags:
 
 ### publish
 
-Queues a tiling _job_ using the recipe provided. Returns a job ID for progress tracking.
+Queues a tiling _job_ using the recipe provided. Use to publish a new tileset or updating an existing one. Returns a job ID for progress tracking.
 
 ```
 tilesets publish <tileset_id>


### PR DESCRIPTION
This PR updates the README to clarify that the `publish` command can be used to both publish a new tileset and update an existing one.

@mapsam for review.