### PR TITLE
list tilesets for an account

### DIFF
--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+from click.testing import CliRunner
+import pytest
+
+from tilesets.cli import list
+
+
+class MockResponse():
+    def __init__(self, mock_text):
+        self.text = mock_text
+        self.status_code = 200
+    def MockResponse(self):
+        return self
+
+
+class MockResponseError():
+    def __init__(self, mock_text):
+        self.text = mock_text
+        self.status_code = 404
+    def MockResponse(self):
+        return self
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch('requests.get')
+def test_cli_list(mock_request_get):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_get.return_value = MockResponse('[{"id":"test.tileset-1","something":"beep"},{"id":"test.tileset-2","something":"boop"}]');
+    result = runner.invoke(list, ['test'])
+    mock_request_get.assert_called_with('https://api.mapbox.com/tilesets/v1/test?access_token=fake-token')
+    assert result.exit_code == 0
+    assert 'test.tileset-1\ntest.tileset-2\n' in result.output
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch('requests.get')
+def test_cli_list_verbose(mock_request_get):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_get.return_value = MockResponse('[{"id":"test.tileset-1","something":"beep"},{"id":"test.tileset-2","something":"boop"}]');
+    result = runner.invoke(list, ['test', '--verbose'])
+    mock_request_get.assert_called_with('https://api.mapbox.com/tilesets/v1/test?access_token=fake-token')
+    assert result.exit_code == 0
+    assert '"something": "beep"\n' in result.output
+    assert '"something": "boop"\n' in result.output

--- a/tilesets/cli.py
+++ b/tilesets/cli.py
@@ -140,6 +140,33 @@ def job(tileset, job_id, token=None):
     utils.print_response(r.text)
 
 
+@cli.command('list')
+@click.argument('username', required=True, type=str)
+@click.option('--verbose', '-v', required=False, is_flag=True, help='Will print all tileset information')
+@click.option('--token', '-t', required=False, type=str, help='Mapbox access token')
+def list(username, verbose, token=None):
+    """List all tilesets for an account.
+    By default the response is a simple list of tileset IDs.
+    If you would like an array of all tileset's information,
+    use the --versbose flag.
+
+    tilests list <username>
+    """
+    mapbox_api = _get_api()
+    mapbox_token = _get_token(token)
+    url = '{0}/tilesets/v1/{1}?access_token={2}'.format(mapbox_api, username, mapbox_token)
+    r = requests.get(url)
+    if r.status_code == 200:
+        if verbose:
+            utils.print_response(r.text)
+        else:
+            j = json.loads(r.text)
+            for tileset in j:
+                click.echo(tileset['id'])
+    else:
+        click.echo(r.text)
+
+
 @cli.command('validate-recipe')
 @click.argument('recipe', required=True, type=click.Path(exists=True))
 @click.option('--token', '-t', required=False, type=str, help='Mapbox access token')


### PR DESCRIPTION
Adds the `tilesets list <account>` command

Default is a simple list:

```
mapsam.tileset-1
mapsam.tileset-2
...
```

`--verbose` flag prints out the entire response from the Tilesets API list endpoint.

This does not include pagination or any of the possible query options for this endpoint.

cc @mapbox/maps-api @l-r 