### PR TITLE
handing non json response + requirements in setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.2 (2019-10-08)
+- Handling for non-json response from recipe validation
+- Adding cligj to setup for install w/o requirements
+
 # 0.3.1 (2019-10-01)
 - Fixed bug for list tilesets
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="tilesets-cli",
-    version="0.3.1",
+    version="0.3.2",
     description=u"CLI for interacting with and preparing data for the Tilesets API",
     long_description=long_description,
     classifiers=[],

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 from codecs import open as codecs_open
 from setuptools import setup, find_packages
 
+from tilesets import __version__
 
 # Get the long description from the relevant file
 with codecs_open("README.md", encoding="utf-8") as f:
@@ -14,7 +15,7 @@ def read(fname):
 
 setup(
     name="tilesets-cli",
-    version="0.3.2",
+    version=__version__,
     description=u"CLI for interacting with and preparing data for the Tilesets API",
     long_description=long_description,
     classifiers=[],

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     install_requires=[
         "boto3",
         "click~=7.0",
+        "cligj",
         "requests",
         "jsonschema~=3.0",
         "jsonseq~=1.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,10 @@ class _MockResponse:
         return self
 
     def json(self):
+        # 201 currently do not have a json response
+        if self.status_code == 201:
+            raise
+
         return self._json
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 import json
 
+from json.decoder import JSONDecodeError
+
 
 @pytest.fixture(scope="function")
 def token_environ(monkeypatch):
@@ -20,7 +22,7 @@ class _MockResponse:
     def json(self):
         # 201 currently do not have a json response
         if self.status_code == 201:
-            raise
+            raise JSONDecodeError("Expecting value", "", 0)
 
         return self._json
 

--- a/tests/test_cli_update_recipe.py
+++ b/tests/test_cli_update_recipe.py
@@ -2,6 +2,8 @@ from click.testing import CliRunner
 from unittest import mock
 import pytest
 
+from json.decoder import JSONDecodeError
+
 from tilesets.scripts.cli import update_recipe
 
 
@@ -44,3 +46,9 @@ def test_cli_update_recipe2(mock_request_patch, MockResponse):
         json={"minzoom": 0, "maxzoom": 10, "layer_name": "test_layer"},
     )
     assert result.exit_code == 0
+
+
+def test_201_mocking(MockResponse):
+    mocker = MockResponse({}, status_code=201)
+    with pytest.raises(JSONDecodeError):
+        mocker.json()

--- a/tests/test_cli_update_recipe.py
+++ b/tests/test_cli_update_recipe.py
@@ -19,7 +19,7 @@ def test_cli_update_recipe(mock_request_patch, MockResponse):
     runner = CliRunner()
 
     # sends expected request
-    mock_request_patch.return_value = MockResponse("", status_code=201)
+    mock_request_patch.return_value = MockResponse({}, status_code=201)
     result = runner.invoke(update_recipe, ["test.id", "tests/fixtures/recipe.json"])
     mock_request_patch.assert_called_with(
         "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=fake-token",
@@ -32,7 +32,7 @@ def test_cli_update_recipe(mock_request_patch, MockResponse):
 @mock.patch("requests.patch")
 def test_cli_update_recipe2(mock_request_patch, MockResponse):
     runner = CliRunner()
-    mock_request_patch.return_value = MockResponse("", status_code=201)
+    mock_request_patch.return_value = MockResponse({}, status_code=201)
     # Provides the flag --token
     result = runner.invoke(
         update_recipe,

--- a/tests/test_cli_update_recipe.py
+++ b/tests/test_cli_update_recipe.py
@@ -32,6 +32,7 @@ def test_cli_update_recipe(mock_request_patch, MockResponse):
 @mock.patch("requests.patch")
 def test_cli_update_recipe2(mock_request_patch, MockResponse):
     runner = CliRunner()
+
     mock_request_patch.return_value = MockResponse({}, status_code=201)
     # Provides the flag --token
     result = runner.invoke(

--- a/tests/test_version_documentation.py
+++ b/tests/test_version_documentation.py
@@ -1,0 +1,7 @@
+from tilesets import __version__
+
+
+def test_versions():
+    mod_version = __version__
+    with open("./CHANGELOG.md") as src:
+        assert len([l in l for l in src if mod_version in l]) == 1

--- a/tilesets/__init__.py
+++ b/tilesets/__init__.py
@@ -1,3 +1,3 @@
 """tilesets package"""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/tilesets/scripts/cli.py
+++ b/tilesets/scripts/cli.py
@@ -236,7 +236,7 @@ def validate_recipe(recipe, token=None, indent=None):
         recipe_json = json.load(json_recipe)
 
         r = requests.put(url, json=recipe_json)
-        click.echo(json.dumps(r.json()), indent=indent)
+        click.echo(json.dumps(r.json(), indent=indent))
 
 
 @cli.command("view-recipe")
@@ -281,7 +281,7 @@ def update_recipe(tileset, recipe, token=None, indent=None):
         r = requests.patch(url, json=recipe_json)
         if r.status_code == 201:
             click.echo("Updated recipe.", err=True)
-            click.echo(r.text, indent=indent)
+            click.echo(r.text)
         else:
             raise errors.TilesetsError(r.text)
 

--- a/tilesets/scripts/cli.py
+++ b/tilesets/scripts/cli.py
@@ -236,7 +236,7 @@ def validate_recipe(recipe, token=None, indent=None):
         recipe_json = json.load(json_recipe)
 
         r = requests.put(url, json=recipe_json)
-        click.echo(json.dumps(r.json(), indent=indent))
+        click.echo(json.dumps(r.json()), indent=indent)
 
 
 @cli.command("view-recipe")
@@ -281,7 +281,7 @@ def update_recipe(tileset, recipe, token=None, indent=None):
         r = requests.patch(url, json=recipe_json)
         if r.status_code == 201:
             click.echo("Updated recipe.", err=True)
-            click.echo(json.dumps(r.json(), indent=indent))
+            click.echo(r.text, indent=indent)
         else:
             raise errors.TilesetsError(r.text)
 


### PR DESCRIPTION
Adds:

- `cligj` in setup.py (so that `pip install .` will work (vs needing `pip install -r requirements.txt`)
- Handling non-json response for `update-recipe`

cc @ericfischer @dianeschulze 