### PR TITLE
Throw exception if no access token is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Pin pytest version
 - Add `--type`, `--visibility`, `--sortby`, and `--limit` options to `list` command
 - Make TilesetNameError message more descriptive
+- Fail early if no access_token is provided
 
 # 1.1.0.dev0 (2020-06-11)
 - `update-recipe` command handles 204 status code in addition to 201 and no longer prints response text

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -159,8 +159,8 @@ def update(
 
     tilesets update <tileset_id>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
     s = utils._get_session()
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
@@ -196,8 +196,8 @@ def delete(tileset, token=None, indent=None, force=None):
     tilesets delete <tileset_id>
     """
 
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
     s = utils._get_session()
 
     if not force:
@@ -253,8 +253,8 @@ def tilejson(tileset, token=None, indent=None, secure=False):
 
     tilesets tilejson <tileset_id>,<tileset_id>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
     s = utils._get_session()
 
     # validate tilesets by splitting comma-delimted string

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -1,39 +1,13 @@
 """Tilesets command line interface"""
-import os
 import json
 import tempfile
 
 import click
 import cligj
-from requests import Session
 from requests_toolbelt import MultipartEncoder
 
 import mapbox_tilesets
 from mapbox_tilesets import utils, errors
-
-
-def _get_token(token=None):
-    """Get Mapbox access token from arg or environment"""
-    if token is not None:
-        return token
-    else:
-        return os.environ.get("MAPBOX_ACCESS_TOKEN") or os.environ.get(
-            "MapboxAccessToken"
-        )
-
-
-def _get_api():
-    """Get Mapbox tileset API base URL from environment"""
-    return os.environ.get("MAPBOX_API", "https://api.mapbox.com")
-
-
-def _get_session(
-    application=mapbox_tilesets.__name__, version=mapbox_tilesets.__version__
-):
-    """Get a configured session"""
-    s = Session()
-    s.headers.update({"user-agent": "{}/{}".format(application, version)})
-    return s
 
 
 @click.version_option(version=mapbox_tilesets.__version__, message="%(version)s")
@@ -92,9 +66,9 @@ def create(
     <tileset_id> is in the form of username.handle - for example "mapbox.neat-tileset".
     The handle may only include "-" or "_" special characters and must be 32 characters or fewer.
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -134,9 +108,9 @@ def publish(tileset, token=None, indent=None):
 
     tilesets publish <tileset_id>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}/publish?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -187,7 +161,7 @@ def update(
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
-    s = _get_session()
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -224,7 +198,7 @@ def delete(tileset, token=None, indent=None, force=None):
 
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
-    s = _get_session()
+    s = utils._get_session()
 
     if not force:
         val = click.prompt(
@@ -255,9 +229,9 @@ def status(tileset, token=None, indent=None):
 
     tilesets status <tileset_id>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}/status?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -281,7 +255,7 @@ def tilejson(tileset, token=None, indent=None, secure=False):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
-    s = _get_session()
+    s = utils._get_session()
 
     # validate tilesets by splitting comma-delimted string
     # and rejoining it
@@ -312,9 +286,9 @@ def jobs(tileset, stage, token=None, indent=None):
 
     tilesets jobs <tileset_id>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}/jobs?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -340,9 +314,9 @@ def job(tileset, job_id, token=None, indent=None):
 
     tilesets job <tileset_id> <job_id>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}/jobs/{2}?access_token={3}".format(
         mapbox_api, tileset, job_id, mapbox_token
     )
@@ -404,9 +378,9 @@ def list(
 
     tilests list <username>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, username, mapbox_token
     )
@@ -435,9 +409,9 @@ def validate_recipe(recipe, token=None, indent=None):
 
     tilesets validate-recipe <path_to_recipe>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/validateRecipe?access_token={1}".format(
         mapbox_api, mapbox_token
     )
@@ -457,9 +431,9 @@ def view_recipe(tileset, token=None, indent=None):
 
     tilesets view-recipe <tileset_id>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}/recipe?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -482,9 +456,9 @@ def update_recipe(tileset, recipe, token=None, indent=None):
 
     tilesets update-recipe <tileset_id> <path_to_recipe>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/{1}/recipe?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -525,9 +499,9 @@ def add_source(ctx, username, id, features, no_validation, token=None, indent=No
 
     tilesets add-source <username> <id> <path/to/source/data>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = (
         f"{mapbox_api}/tilesets/v1/sources/{username}/{id}?access_token={mapbox_token}"
     )
@@ -565,9 +539,9 @@ def view_source(username, id, token=None, indent=None):
 
     tilesets view-source <username> <id>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/sources/{1}/{2}?access_token={3}".format(
         mapbox_api, username, id, mapbox_token
     )
@@ -600,9 +574,9 @@ def delete_source(username, id, force, token=None):
                 f"{val} does not match {username}/{id}. Aborted!"
             )
 
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/sources/{1}/{2}?access_token={3}".format(
         mapbox_api, username, id, mapbox_token
     )
@@ -621,9 +595,9 @@ def list_sources(username, token=None):
 
     tilesets list-sources <username>
     """
-    mapbox_api = _get_api()
-    mapbox_token = _get_token(token)
-    s = _get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
     url = "{0}/tilesets/v1/sources/{1}?access_token={2}".format(
         mapbox_api, username, mapbox_token
     )

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -18,7 +18,7 @@ def _get_token(token=None):
     if token is not None:
         return token
 
-    raise Exception(
+    raise mapbox_tilesets.errors.TilesetsError(
         "No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag."
     )
 

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -1,6 +1,34 @@
+import os
 import re
 
 from jsonschema import validate
+from requests import Session
+
+import mapbox_tilesets
+
+
+def _get_token(token=None):
+    """Get Mapbox access token from arg or environment"""
+    token = token or os.environ.get("MAPBOX_ACCESS_TOKEN") or os.environ.get("MapboxAccessToken")
+
+    if token is not None:
+        return token
+
+    raise Exception('No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag.')
+
+
+def _get_api():
+    """Get Mapbox tileset API base URL from environment"""
+    return os.environ.get("MAPBOX_API", "https://api.mapbox.com")
+
+
+def _get_session(
+    application=mapbox_tilesets.__name__, version=mapbox_tilesets.__version__
+):
+    """Get a configured session"""
+    s = Session()
+    s.headers.update({"user-agent": "{}/{}".format(application, version)})
+    return s
 
 
 def validate_tileset_id(tileset_id):

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -9,12 +9,18 @@ import mapbox_tilesets
 
 def _get_token(token=None):
     """Get Mapbox access token from arg or environment"""
-    token = token or os.environ.get("MAPBOX_ACCESS_TOKEN") or os.environ.get("MapboxAccessToken")
+    token = (
+        token
+        or os.environ.get("MAPBOX_ACCESS_TOKEN")
+        or os.environ.get("MapboxAccessToken")
+    )
 
     if token is not None:
         return token
 
-    raise Exception('No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag.')
+    raise Exception(
+        "No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag."
+    )
 
 
 def _get_api():

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -30,6 +30,19 @@ def test_cli_add_source(mock_request_post, MockResponse):
     )
 
 
+def test_cli_add_source_no_token():
+    runner = CliRunner()
+    unauthenticated_result = runner.invoke(
+        add_source, ["test-user", "hello-world", "tests/fixtures/valid.ldgeojson"]
+    )
+    assert unauthenticated_result.exit_code == 1
+
+    assert (
+        str(unauthenticated_result.exception)
+        == """No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag."""
+    )
+
+
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.Session.post")
 def test_cli_add_source_no_validation(mock_request_post, MockResponse):

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
-from unittest import mock
 import json
+import os
+from unittest import mock
 
 import pytest
 
@@ -31,6 +32,11 @@ def test_cli_add_source(mock_request_post, MockResponse):
 
 
 def test_cli_add_source_no_token():
+    if "MAPBOX_ACCESS_TOKEN" in os.environ:
+        del os.environ["MAPBOX_ACCESS_TOKEN"]
+    if "MapboxAccessToken" in os.environ:
+        del os.environ["MapboxAccessToken"]
+
     runner = CliRunner()
     unauthenticated_result = runner.invoke(
         add_source, ["test-user", "hello-world", "tests/fixtures/valid.ldgeojson"]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,0 @@
-from mapbox_tilesets.scripts.cli import _get_session
-
-
-def test_get_session():
-    s = _get_session("my_application", "1.0.0")
-    assert "user-agent" in s.headers
-    assert s.headers["user-agent"] == "my_application/1.0.0"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import os
+import pytest
 from mapbox_tilesets.utils import _get_session, _get_token, validate_tileset_id
+from mapbox_tilesets.errors import TilesetsError
 
 
 def test_get_session():
@@ -17,22 +19,21 @@ def test_get_token_environment_variables():
     token1 = "token-environ1"
     token2 = "token-environ2"
     os.environ["MAPBOX_ACCESS_TOKEN"] = token1
-    assert token1 == _get_token(None)
+    assert token1 == _get_token()
     del os.environ["MAPBOX_ACCESS_TOKEN"]
     os.environ["MapboxAccessToken"] = token2
-    assert token2 == _get_token(None)
+    assert token2 == _get_token()
     del os.environ["MapboxAccessToken"]
 
 
 def test_get_token_errors_without_token():
-    try:
+    with pytest.raises(TilesetsError) as excinfo:
         _get_token()
-        assert False
-    except Exception as e:
-        assert (
-            str(e)
-            == "No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag."
-        )
+
+    assert (
+        str(excinfo.value)
+        == "No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag."
+    )
 
 
 def test_validate_tileset_id():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,13 +9,13 @@ def test_get_session():
 
 
 def test_get_token_parameter():
-    token = 'token-parameter'
+    token = "token-parameter"
     assert token == _get_token(token)
 
 
 def test_get_token_environment_variables():
-    token1 = 'token-environ1'
-    token2 = 'token-environ2'
+    token1 = "token-environ1"
+    token2 = "token-environ2"
     os.environ["MAPBOX_ACCESS_TOKEN"] = token1
     assert token1 == _get_token(None)
     del os.environ["MAPBOX_ACCESS_TOKEN"]
@@ -26,10 +26,13 @@ def test_get_token_environment_variables():
 
 def test_get_token_errors_without_token():
     try:
-        _get_token(None)
+        _get_token()
         assert False
     except Exception as e:
-        assert str(e) == 'No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag.'
+        assert (
+            str(e)
+            == "No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag."
+        )
 
 
 def test_validate_tileset_id():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,35 @@
-from mapbox_tilesets.utils import validate_tileset_id
+import os
+from mapbox_tilesets.utils import _get_session, _get_token, validate_tileset_id
+
+
+def test_get_session():
+    s = _get_session("my_application", "1.0.0")
+    assert "user-agent" in s.headers
+    assert s.headers["user-agent"] == "my_application/1.0.0"
+
+
+def test_get_token_parameter():
+    token = 'token-parameter'
+    assert token == _get_token(token)
+
+
+def test_get_token_environment_variables():
+    token1 = 'token-environ1'
+    token2 = 'token-environ2'
+    os.environ["MAPBOX_ACCESS_TOKEN"] = token1
+    assert token1 == _get_token(None)
+    del os.environ["MAPBOX_ACCESS_TOKEN"]
+    os.environ["MapboxAccessToken"] = token2
+    assert token2 == _get_token(None)
+    del os.environ["MapboxAccessToken"]
+
+
+def test_get_token_errors_without_token():
+    try:
+        _get_token(None)
+        assert False
+    except Exception as e:
+        assert str(e) == 'No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag.'
 
 
 def test_validate_tileset_id():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,20 @@
 import os
 import pytest
-from mapbox_tilesets.utils import _get_session, _get_token, validate_tileset_id
+from mapbox_tilesets.utils import (
+    _get_api,
+    _get_session,
+    _get_token,
+    validate_tileset_id,
+)
 from mapbox_tilesets.errors import TilesetsError
+
+
+def test_get_api():
+    api = _get_api()
+    assert api == "https://api.mapbox.com"
+    os.environ["MAPBOX_API"] = "https://different.com"
+    api = _get_api()
+    assert api == "https://different.com"
 
 
 def test_get_session():


### PR DESCRIPTION
Summary of changes:

1. Moving `_get_token` and `_get_api` to `utils.py`
2. Throwing exception before making request, if token is not provided
3. Adding tests
4. Updates to make the linter happy