### PR TITLE
update-recipe succeeds on 201 or 204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- `update-recipe` command handles 204 status code in addition to 201 and no longer prints response text
+
 # 1.0.1.dev0 (2020-04-07)
 - Fixed http status code for tilesets sources delete so it will no longer error
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -281,7 +281,6 @@ def update_recipe(tileset, recipe, token=None, indent=None):
         r = requests.patch(url, json=recipe_json)
         if r.status_code == 201 or r.status_code == 204:
             click.echo("Updated recipe.", err=True)
-            click.echo(r.text)
         else:
             raise errors.TilesetsError(r.text)
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -279,7 +279,7 @@ def update_recipe(tileset, recipe, token=None, indent=None):
         recipe_json = json.load(json_recipe)
 
         r = requests.patch(url, json=recipe_json)
-        if r.status_code == 201:
+        if r.status_code == 201 or r.status_code == 204:
             click.echo("Updated recipe.", err=True)
             click.echo(r.text)
         else:

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -292,7 +292,7 @@ def validate_source(features):
     """Validate your source file.
     $ tilesets validate-source <path/to/your/src/file>
     """
-    click.echo(f"Validating features", err=True)
+    click.echo("Validating features", err=True)
 
     for feature in features:
         utils.validate_geojson(feature)

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -44,7 +44,9 @@ def test_cli_list_verbose(mock_request_get, MockResponse):
     )
     assert result.exit_code == 0
 
-    assert [json.loads(l.strip()) for l in result.output.split("\n") if l] == message
+    assert [
+        json.loads(tileset.strip()) for tileset in result.output.split("\n") if tileset
+    ] == message
 
 
 @pytest.mark.usefixtures("token_environ")

--- a/tests/test_cli_update_recipe.py
+++ b/tests/test_cli_update_recipe.py
@@ -17,7 +17,7 @@ def test_cli_update_recipe_no_recipe():
 
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.patch")
-def test_cli_update_recipe(mock_request_patch, MockResponse):
+def test_cli_update_recipe_201(mock_request_patch, MockResponse):
     runner = CliRunner()
 
     # sends expected request
@@ -32,10 +32,25 @@ def test_cli_update_recipe(mock_request_patch, MockResponse):
 
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.patch")
+def test_cli_update_recipe_204(mock_request_patch, MockResponse):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_patch.return_value = MockResponse("", status_code=204)
+    result = runner.invoke(update_recipe, ["test.id", "tests/fixtures/recipe.json"])
+    mock_request_patch.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=fake-token",
+        json={"minzoom": 0, "maxzoom": 10, "layer_name": "test_layer"},
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.patch")
 def test_cli_update_recipe2(mock_request_patch, MockResponse):
     runner = CliRunner()
 
-    mock_request_patch.return_value = MockResponse({}, status_code=201)
+    mock_request_patch.return_value = MockResponse("", status_code=204)
     # Provides the flag --token
     result = runner.invoke(
         update_recipe,

--- a/tests/test_version_documentation.py
+++ b/tests/test_version_documentation.py
@@ -4,4 +4,4 @@ from mapbox_tilesets import __version__
 def test_versions():
     mod_version = __version__
     with open("./CHANGELOG.md") as src:
-        assert len([l in l for l in src if mod_version in l]) == 1
+        assert len([line in line for line in src if mod_version in line]) == 1


### PR DESCRIPTION
- A few linty changes to make flake8 happy after version bump
- Changes `update-recipe` to check for either a 201 or 204 response code indicating success 
- update-recipe longer prints the response text `Created`

### Before:
```shell
$ tilesets update-recipe username.tileset recipe.json
Updated recipe.
Created
```

### After:
```shell
$ tilesets update-recipe username.tileset recipe.json
Updated recipe.
```