### PR TITLE
Update tileset information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+- Add `update` command for updating `--name`, `--description`, `--privacy`, and `--attribution` of a tileset
+- Add `--attribution` option to the `create` command
+
 # 1.0.1.dev0 (2020-04-07)
 - Fixed http status code for tilesets sources delete so it will no longer error
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ export MAPBOX_ACCESS_TOKEN=my.token
 tilesets add-source <username> <id> <file>
 ```
 
+Adds GeoJSON files to a source for tiling. Accepts line-delimited GeoJSON or GeoJSON feature collections as files or via `stdin`. The CLI automatically converts data to line-delimited GeoJSON prior to uploading. 
+
 Flags:
 
 * `--no-validation` [optional]: do not validate source data locally before uploading
@@ -70,10 +72,9 @@ tilesets add-source <username> <id> ./file.geojson
 tilesets add-source <username> <id> file-1.geojson file-4.geojson
 
 # directory of files
+# Reading from a directory will not distinguish between GeoJSON files and non GeoJSON files. All source files will be run through our validator unless you pass the `--no-validation` flag.
 tilesets add-source <username> <id> ./path/to/multiple/files/
 ```
-
-Reading from a directory will not distinguish between GeoJSON files and non GeoJSON files. All source files will be run through our validator unless you pass the `--no-validation` flag.
 
 ### validate-source
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ export MAPBOX_ACCESS_TOKEN=my.token
 * Tilesets
   * [`create`](#create)
   * [`publish`](#publish)
+  * [`update`](#update)
   * [`status`](#status)
   * [`job`](#job)
   * [`jobs`](#jobs)
@@ -56,7 +57,7 @@ export MAPBOX_ACCESS_TOKEN=my.token
 tilesets add-source <username> <id> <file>
 ```
 
-Adds GeoJSON files to a source for tiling. Accepts line-delimited GeoJSON or GeoJSON feature collections as files or via `stdin`. The CLI automatically converts data to line-delimited GeoJSON prior to uploading. 
+Adds GeoJSON files to a source for tiling. Accepts line-delimited GeoJSON or GeoJSON feature collections as files or via `stdin`. The CLI automatically converts data to line-delimited GeoJSON prior to uploading.
 
 Flags:
 
@@ -177,6 +178,7 @@ Flags:
 * `--name` or `-n` [required]: human-readable name of your tileset. (If your tileset_id is user.my_amazing_tileset, you might want your `name` field to be "My Amazing Tileset".)
 * `--description` or `-d`: description of your tileset
 * `--privacy` or `-p`: Set the privacy of the tileset. Allowed values are `private` and `public`. If not provided, will default to your plan level on Mapbox.com. Pay-As-You-Go plans only support public maps.
+* `--attribution` or `-a` [optional]: set tileset attribution. Must be a JSON string, specifically an array of attribution objects, each with `text` and `link` keys. Limited to three attribution objects, 80 characters maximum combined across all text values, and 1000 characters maximum combined across all link values.
 
 ### publish
 
@@ -185,6 +187,25 @@ Queues a tiling _job_ using the recipe provided. Use to publish a new tileset or
 ```
 tilesets publish <tileset_id>
 ```
+
+### update
+
+Update a tileset's information.
+
+```
+tilesets update <tileset_id>
+  --name "Hello World"
+  --description "Say hi to the world"
+  --privacy=private
+  --attribution='[{"text":"© Hola Mundo","link":"http://example.com"}]'
+```
+
+Flags:
+
+* `--name` or `-n` [optional]: update tileset name
+* `--description` or `-d` [optional]: update tileset description
+* `--privacy` or `-p` [optional]: set your tileset to `public` or `private`
+* `--attribution` or `-a` [optional]: set tileset attribution. Must be a JSON string, specifically an array of attribution objects, each with `text` and `link` keys. Limited to three attribution objects, 80 characters maximum combined across all text values, and 1000 characters maximum combined across all link values.
 
 ### status
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -58,10 +58,23 @@ def cli():
     type=click.Choice(["public", "private"]),
     help="set the tileset privacy options",
 )
+@click.option(
+    "--attribution",
+    required=False,
+    type=str,
+    help="attribution for the tileset in the form of a JSON string - Array<Object<text,link>>",
+)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
 def create(
-    tileset, recipe, name=None, description=None, privacy=None, token=None, indent=None
+    tileset,
+    recipe,
+    name=None,
+    description=None,
+    privacy=None,
+    attribution=None,
+    token=None,
+    indent=None,
 ):
     """Create a new tileset with a recipe.
 
@@ -87,6 +100,13 @@ def create(
     if recipe:
         with open(recipe) as json_recipe:
             body["recipe"] = json.load(json_recipe)
+
+    if attribution:
+        try:
+            body["attribution"] = json.loads(attribution)
+        except:
+            click.echo("Unable to parse attribution JSON")
+            click.exit(1)
 
     r = requests.post(url, json=body)
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -135,7 +135,7 @@ def publish(tileset, token=None, indent=None):
             err=True,
         )
     else:
-        raise errors.TilesetsError(f"{r.text}")
+        raise errors.TilesetsError(r.text)
 
 
 @cli.command("update")
@@ -194,7 +194,7 @@ def update(
     r = requests.patch(url, json=body)
 
     if r.status_code != 204:
-        raise errors.TilesetsError(f"{r.text}")
+        raise errors.TilesetsError(r.text)
 
 
 @cli.command("status")

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -118,6 +118,65 @@ def publish(tileset, token=None, indent=None):
         raise errors.TilesetsError(f"{r.text}")
 
 
+@cli.command("update")
+@click.argument("tileset", required=True, type=str)
+@click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
+@click.option("--indent", type=int, default=None, help="Indent for JSON output")
+@click.option("--name", "-n", required=False, type=str, help="name of the tileset")
+@click.option(
+    "--description", "-d", required=False, type=str, help="description of the tileset"
+)
+@click.option(
+    "--privacy",
+    "-p",
+    required=False,
+    type=click.Choice(["public", "private"]),
+    help="set the tileset privacy options",
+)
+@click.option(
+    "--attribution",
+    required=False,
+    type=str,
+    help="attribution for the tileset in the form of a JSON string - Array<Object<text,link>>",
+)
+def update(
+    tileset,
+    token=None,
+    indent=None,
+    name=None,
+    description=None,
+    privacy=None,
+    attribution=None,
+):
+    """Update a tileset's information.
+
+    tilesets update <tileset_id>
+    """
+    mapbox_api = _get_api()
+    mapbox_token = _get_token(token)
+    url = "{0}/tilesets/v1/{1}?access_token={2}".format(
+        mapbox_api, tileset, mapbox_token
+    )
+    body = {}
+    if name:
+        body["name"] = name
+    if description:
+        body["description"] = description
+    if privacy:
+        body["private"] = True if privacy == "private" else False
+    if attribution:
+        try:
+            body["attribution"] = json.loads(attribution)
+        except:
+            click.echo("Unable to parse attribution JSON")
+            click.exit(1)
+
+    r = requests.patch(url, json=body)
+
+    if r.status_code != 204:
+        raise errors.TilesetsError(f"{r.text}")
+
+
 @cli.command("status")
 @click.argument("tileset", required=True, type=str)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
@@ -292,7 +351,7 @@ def validate_source(features):
     """Validate your source file.
     $ tilesets validate-source <path/to/your/src/file>
     """
-    click.echo(f"Validating features", err=True)
+    click.echo("Validating features", err=True)
 
     for feature in features:
         utils.validate_geojson(feature)

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -45,6 +45,7 @@ def test_cli_create_success(mock_request_post, MockResponse):
             "--name",
             "test name",
             '--attribution=[{"text":"natural earth data","link":"https://naturalearthdata.com"}]',
+            "--privacy=private",
         ],
     )
     assert result.exit_code == 0
@@ -57,9 +58,31 @@ def test_cli_create_success(mock_request_post, MockResponse):
             "attribution": [
                 {"text": "natural earth data", "link": "https://naturalearthdata.com"}
             ],
+            "private": True,
         },
     )
     assert json.loads(result.output) == message
+
+
+@pytest.mark.usefixtures("token_environ")
+def test_cli_create_attribution_json_parse_error():
+    runner = CliRunner()
+    # sends request to proper endpoints
+    result = runner.invoke(
+        create,
+        [
+            "test.id",
+            "--recipe",
+            "tests/fixtures/recipe.json",
+            "--name",
+            "test name",
+            "--attribution",
+            "not valid json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Unable to parse attribution JSON" in result.output
 
 
 @pytest.mark.usefixtures("token_environ")

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -38,7 +38,14 @@ def test_cli_create_success(mock_request_post, MockResponse):
     mock_request_post.return_value = MockResponse(message)
     result = runner.invoke(
         create,
-        ["test.id", "--recipe", "tests/fixtures/recipe.json", "--name", "test name"],
+        [
+            "test.id",
+            "--recipe",
+            "tests/fixtures/recipe.json",
+            "--name",
+            "test name",
+            '--attribution=[{"text":"natural earth data","link":"https://naturalearthdata.com"}]',
+        ],
     )
     assert result.exit_code == 0
     mock_request_post.assert_called_with(
@@ -47,6 +54,9 @@ def test_cli_create_success(mock_request_post, MockResponse):
             "name": "test name",
             "description": "",
             "recipe": {"minzoom": 0, "maxzoom": 10, "layer_name": "test_layer"},
+            "attribution": [
+                {"text": "natural earth data", "link": "https://naturalearthdata.com"}
+            ],
         },
     )
     assert json.loads(result.output) == message

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,0 +1,80 @@
+import json
+import pytest
+
+from click.testing import CliRunner
+from unittest import mock
+
+from mapbox_tilesets.scripts.cli import update
+
+
+class MockResponse:
+    def __init__(self, mock_json, status_code):
+        self.text = json.dumps(mock_json)
+        self._json = mock_json
+        self.status_code = status_code
+
+    def MockResponse(self):
+        return self
+
+    def json(self):
+        return self._json
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.patch")
+def test_cli_patch(mock_request_patch):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_patch.return_value = MockResponse("", 204)
+    result = runner.invoke(
+        update,
+        [
+            "test.id",
+            "--name=hola",
+            "--description=hello world",
+            "--privacy=private",
+            '--attribution=[{"text":"natural earth data","link":"https://naturalearthdata.com"}]',
+        ],
+    )
+
+    mock_request_patch.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token",
+        json={
+            "name": "hola",
+            "description": "hello world",
+            "private": True,
+            "attribution": [
+                {"text": "natural earth data", "link": "https://naturalearthdata.com"}
+            ],
+        },
+    )
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.patch")
+def test_cli_patch_no_options(mock_request_patch):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_patch.return_value = MockResponse("", 204)
+    result = runner.invoke(update, ["test.id"])
+
+    mock_request_patch.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token", json={}
+    )
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+@pytest.mark.usefixtures("token_environ")
+def test_cli_patch_invalid_json():
+    runner = CliRunner()
+
+    # send invalid json request
+    result = runner.invoke(update, ["test.id", "--attribution=invalid json"])
+
+    assert result.exit_code == 1
+    assert "Unable to parse attribution JSON" in result.output


### PR DESCRIPTION
Adds a new command `tilesets update` for updating the following attributes, as described [in the docs](https://docs.mapbox.com/api/maps/#update-tileset-information):

* --name
* --description
* --privacy
* --attribution

Also adds the `--attribution` flag to the `tilesets create` command, as well as updates docs for the new and updated commands.

cc @dianeschulze 

