### PR TITLE
Delete tileset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `update` command for updating `--name`, `--description`, `--privacy`, and `--attribution` of a tileset
 - Add `--attribution` option to the `create` command
 - Add `delete` command for deleting a tileset
+- Add `tilejson` command
 
 # 1.0.1.dev0 (2020-04-07)
 - Fixed http status code for tilesets sources delete so it will no longer error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - `update-recipe` command handles 204 status code in addition to 201 and no longer prints response text
 - Add `update` command for updating `--name`, `--description`, `--privacy`, and `--attribution` of a tileset
 - Add `--attribution` option to the `create` command
+- Add `delete` command for deleting a tileset
 
 # 1.0.1.dev0 (2020-04-07)
 - Fixed http status code for tilesets sources delete so it will no longer error

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ export MAPBOX_ACCESS_TOKEN=my.token
   * [`create`](#create)
   * [`publish`](#publish)
   * [`update`](#update)
+  * [`delete`](#delete)
   * [`status`](#status)
   * [`job`](#job)
   * [`jobs`](#jobs)
@@ -206,6 +207,18 @@ Flags:
 * `--description` or `-d` [optional]: update tileset description
 * `--privacy` or `-p` [optional]: set your tileset to `public` or `private`
 * `--attribution` or `-a` [optional]: set tileset attribution. Must be a JSON string, specifically an array of attribution objects, each with `text` and `link` keys. Limited to three attribution objects, 80 characters maximum combined across all text values, and 1000 characters maximum combined across all link values.
+
+### delete
+
+Delete a tileset. By default will prompt you for confirmation before deleting.
+
+```
+tilesets delete <tileset_id>
+```
+
+Flags:
+
+* `--force` or `-f` to bypass confirmation prompt.
 
 ### status
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -212,9 +212,14 @@ def delete(tileset, token=None, indent=None, force=None):
     mapbox_token = _get_token(token)
 
     if not force:
-        click.confirm(
-            "Are you sure you want to delete {0}?".format(tileset), abort=True
+        val = click.prompt(
+            "To confirm tileset deletion please enter the name of the tileset {0}?".format(
+                tileset
+            ),
+            type=str,
         )
+        if val != tileset:
+            raise click.ClickException(f"{val} does not match {tileset}. Aborted!")
 
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
@@ -515,9 +520,17 @@ def delete_source(username, id, force, token=None):
     tilesets delete-source <username> <id>
     """
     if not force:
-        click.confirm(
-            "Are you sure you want to delete {0} {1}?".format(username, id), abort=True
+        val = click.prompt(
+            "To confirm source deletion please enter the name of the tileset {0}/{1}?".format(
+                username, id
+            ),
+            type=str,
         )
+        if val != f"{username}/{id}":
+            raise click.ClickException(
+                f"{val} does not match {username}/{id}. Aborted!"
+            )
+
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
     url = "{0}/tilesets/v1/sources/{1}/{2}?access_token={3}".format(

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -142,7 +142,6 @@ def delete(tileset, token=None, indent=None, force=None):
     )
     r = requests.delete(url)
     if r.status_code != 204:
-        print("hello about to raise")
         raise errors.TilesetsError(r.text)
 
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -213,7 +213,7 @@ def delete(tileset, token=None, indent=None, force=None):
 
     if not force:
         val = click.prompt(
-            "To confirm tileset deletion please enter the name of the tileset {0}?".format(
+            'To confirm tileset deletion please enter the full tileset id "{0}"'.format(
                 tileset
             ),
             type=str,
@@ -521,7 +521,7 @@ def delete_source(username, id, force, token=None):
     """
     if not force:
         val = click.prompt(
-            "To confirm source deletion please enter the name of the tileset {0}/{1}?".format(
+            'To confirm source deletion please enter the full source id "{0}/{1}"'.format(
                 username, id
             ),
             type=str,

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -118,6 +118,34 @@ def publish(tileset, token=None, indent=None):
         raise errors.TilesetsError(f"{r.text}")
 
 
+@cli.command("delete")
+@click.argument("tileset", required=True, type=str)
+@click.option("--force", "-f", is_flag=True, help="Circumvents confirmation prompt")
+@click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
+@click.option("--indent", type=int, default=None, help="Indent for JSON output")
+def delete(tileset, token=None, indent=None, force=None):
+    """Delete your tileset.
+
+    tilesets delete <tileset_id>
+    """
+
+    mapbox_api = _get_api()
+    mapbox_token = _get_token(token)
+
+    if not force:
+        click.confirm(
+            "Are you sure you want to delete {0}?".format(tileset), abort=True
+        )
+
+    url = "{0}/tilesets/v1/{1}?access_token={2}".format(
+        mapbox_api, tileset, mapbox_token
+    )
+    r = requests.delete(url)
+    if r.status_code != 204:
+        print("hello about to raise")
+        raise errors.TilesetsError(r.text)
+
+
 @cli.command("status")
 @click.argument("tileset", required=True, type=str)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -220,7 +220,7 @@ def delete(tileset, token=None, indent=None, force=None):
         mapbox_api, tileset, mapbox_token
     )
     r = requests.delete(url)
-    if r.status_code != 204:
+    if r.status_code != 200 and r.status_code != 204:
         raise errors.TilesetsError(r.text)
 
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -220,7 +220,9 @@ def delete(tileset, token=None, indent=None, force=None):
         mapbox_api, tileset, mapbox_token
     )
     r = requests.delete(url)
-    if r.status_code != 200 and r.status_code != 204:
+    if r.status_code == 200 or r.status_code == 204:
+        click.echo("Tileset deleted.")
+    else:
         raise errors.TilesetsError(r.text)
 
 

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -31,7 +31,25 @@ def test_cli_delete(mock_request_delete):
         "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
     )
     assert result.exit_code == 0
-    assert result.output == "Are you sure you want to delete test.id? [y/N]: y\n"
+    assert (
+        result.output
+        == "Are you sure you want to delete test.id? [y/N]: y\nTileset deleted.\n"
+    )
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.delete")
+def test_cli_delete_prompt_no(mock_request_delete):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_delete.return_value = MockResponse("", status_code=200)
+    result = runner.invoke(delete, ["test.id"], input="n")
+    mock_request_delete.assert_not_called()
+    assert result.exit_code == 1
+    assert (
+        result.output == "Are you sure you want to delete test.id? [y/N]: n\nAborted!\n"
+    )
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -46,7 +64,7 @@ def test_cli_delete_force(mock_request_delete):
         "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
     )
     assert result.exit_code == 0
-    assert result.output == ""
+    assert result.output == "Tileset deleted.\n"
 
 
 @pytest.mark.usefixtures("token_environ")

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -1,0 +1,47 @@
+import json
+import pytest
+
+from click.testing import CliRunner
+from unittest import mock
+
+from mapbox_tilesets.scripts.cli import delete
+
+
+class MockResponse:
+    def __init__(self, mock_json, status_code):
+        self.text = json.dumps(mock_json)
+        self._json = mock_json
+        self.status_code = status_code
+
+    def MockResponse(self):
+        return self
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.delete")
+def test_cli_delete(mock_request_delete):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_delete.return_value = MockResponse("", status_code=204)
+    result = runner.invoke(delete, ["test.id"], input="y")
+    mock_request_delete.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
+    )
+    assert result.exit_code == 0
+    assert result.output == "Are you sure you want to delete test.id? [y/N]: y\n"
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.delete")
+def test_cli_delete_force(mock_request_delete):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_delete.return_value = MockResponse("", status_code=204)
+    result = runner.invoke(delete, ["test.id", "--force"])
+    mock_request_delete.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
+    )
+    assert result.exit_code == 0
+    assert result.output == ""

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -33,7 +33,7 @@ def test_cli_delete(mock_request_delete):
     assert result.exit_code == 0
     assert (
         result.output
-        == "To confirm tileset deletion please enter the name of the tileset test.id?: test.id\nTileset deleted.\n"
+        == 'To confirm tileset deletion please enter the full tileset id "test.id": test.id\nTileset deleted.\n'
     )
 
 
@@ -49,7 +49,7 @@ def test_cli_delete_prompt_no(mock_request_delete):
     assert result.exit_code == 1
     assert (
         result.output
-        == "To confirm tileset deletion please enter the name of the tileset test.id?: wrong.id\nError: wrong.id does not match test.id. Aborted!\n"
+        == 'To confirm tileset deletion please enter the full tileset id "test.id": wrong.id\nError: wrong.id does not match test.id. Aborted!\n'
     )
 
 

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -23,7 +23,7 @@ def test_cli_delete(mock_request_delete):
     runner = CliRunner()
 
     # sends expected request
-    mock_request_delete.return_value = MockResponse("", status_code=204)
+    mock_request_delete.return_value = MockResponse("", status_code=200)
     result = runner.invoke(delete, ["test.id"], input="y")
     mock_request_delete.assert_called_with(
         "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -5,11 +5,13 @@ from click.testing import CliRunner
 from unittest import mock
 
 from mapbox_tilesets.scripts.cli import delete
+from mapbox_tilesets.errors import TilesetsError
 
 
 class MockResponse:
     def __init__(self, mock_json, status_code):
         self.text = json.dumps(mock_json)
+        print(self.text)
         self._json = mock_json
         self.status_code = status_code
 
@@ -45,3 +47,20 @@ def test_cli_delete_force(mock_request_delete):
     )
     assert result.exit_code == 0
     assert result.output == ""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.delete")
+def test_cli_delete_fail(mock_request_delete):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_delete.return_value = MockResponse(
+        {"message": "uh oh"}, status_code=422
+    )
+    result = runner.invoke(delete, ["test.id", "--force"])
+    mock_request_delete.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, TilesetsError)

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -26,14 +26,14 @@ def test_cli_delete(mock_request_delete):
 
     # sends expected request
     mock_request_delete.return_value = MockResponse("", status_code=200)
-    result = runner.invoke(delete, ["test.id"], input="y")
+    result = runner.invoke(delete, ["test.id"], input="test.id")
     mock_request_delete.assert_called_with(
         "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
     )
     assert result.exit_code == 0
     assert (
         result.output
-        == "Are you sure you want to delete test.id? [y/N]: y\nTileset deleted.\n"
+        == "To confirm tileset deletion please enter the name of the tileset test.id?: test.id\nTileset deleted.\n"
     )
 
 
@@ -44,11 +44,12 @@ def test_cli_delete_prompt_no(mock_request_delete):
 
     # sends expected request
     mock_request_delete.return_value = MockResponse("", status_code=200)
-    result = runner.invoke(delete, ["test.id"], input="n")
+    result = runner.invoke(delete, ["test.id"], input="wrong.id")
     mock_request_delete.assert_not_called()
     assert result.exit_code == 1
     assert (
-        result.output == "Are you sure you want to delete test.id? [y/N]: n\nAborted!\n"
+        result.output
+        == "To confirm tileset deletion please enter the name of the tileset test.id?: wrong.id\nError: wrong.id does not match test.id. Aborted!\n"
     )
 
 

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -78,7 +78,7 @@ def test_cli_delete_source(mock_request_delete, MockResponse):
     assert result.exit_code == 0
     assert (
         result.output
-        == "To confirm source deletion please enter the name of the tileset test-user/hello-world?: test-user/hello-world\nSource deleted.\n"
+        == 'To confirm source deletion please enter the full source id "test-user/hello-world": test-user/hello-world\nSource deleted.\n'
     )
     force_result = runner.invoke(delete_source, ["test-user", "hello-world", "--force"])
     assert force_result.exit_code == 0
@@ -96,7 +96,7 @@ def test_cli_delete_source_aborted(mock_request_delete, MockResponse):
     assert result.exit_code == 1
     assert (
         result.output
-        == "To confirm source deletion please enter the name of the tileset test-user/hello-world?: wrong/id\nError: wrong/id does not match test-user/hello-world. Aborted!\n"
+        == 'To confirm source deletion please enter the full source id "test-user/hello-world": wrong/id\nError: wrong/id does not match test-user/hello-world. Aborted!\n'
     )
 
 

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -72,11 +72,13 @@ def test_cli_view_source(mock_request_get, MockResponse):
 def test_cli_delete_source(mock_request_delete, MockResponse):
     mock_request_delete.return_value = MockResponse("", status_code=204)
     runner = CliRunner()
-    result = runner.invoke(delete_source, ["test-user", "hello-world"], input="y")
+    result = runner.invoke(
+        delete_source, ["test-user", "hello-world"], input="test-user/hello-world"
+    )
     assert result.exit_code == 0
     assert (
         result.output
-        == "Are you sure you want to delete test-user hello-world? [y/N]: y\nSource deleted.\n"
+        == "To confirm source deletion please enter the name of the tileset test-user/hello-world?: test-user/hello-world\nSource deleted.\n"
     )
     force_result = runner.invoke(delete_source, ["test-user", "hello-world", "--force"])
     assert force_result.exit_code == 0
@@ -88,11 +90,13 @@ def test_cli_delete_source(mock_request_delete, MockResponse):
 def test_cli_delete_source_aborted(mock_request_delete, MockResponse):
     mock_request_delete.return_value = MockResponse("", status_code=201)
     runner = CliRunner()
-    result = runner.invoke(delete_source, ["test-user", "hello-world"], input="n")
+    result = runner.invoke(
+        delete_source, ["test-user", "hello-world"], input="wrong/id"
+    )
     assert result.exit_code == 1
     assert (
         result.output
-        == "Are you sure you want to delete test-user hello-world? [y/N]: n\nAborted!\n"
+        == "To confirm source deletion please enter the name of the tileset test-user/hello-world?: wrong/id\nError: wrong/id does not match test-user/hello-world. Aborted!\n"
     )
 
 


### PR DESCRIPTION
Adds a `tilesets delete <id>` command for deleting a tileset. By default this requires an extra `y` prompt but you can pass `--force` to bypass.

cc @dianeschulze 