### PR TITLE
add progress bar to add-source command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Make TilesetNameError message more descriptive
 - Fail early if no access_token is provided
 - Add `--limit` option to `jobs` command
+- Update `add-source` to show a progress bar
+- Add `--quiet` option to `add-source` to silence progress bar
 
 # 1.1.0.dev0 (2020-06-11)
 - `update-recipe` command handles 204 status code in addition to 201 and no longer prints response text

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Adds GeoJSON files to a source for tiling. Accepts line-delimited GeoJSON or Geo
 Flags:
 
 * `--no-validation` [optional]: do not validate source data locally before uploading
+* `--quiet` [optional]: do not display an upload progress bar
 
 Usage
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -514,7 +514,6 @@ def add_source(
 
     with tempfile.TemporaryFile() as file:
         for feature in features:
-            print(feature)
             if not no_validation:
                 utils.validate_geojson(feature)
 
@@ -527,7 +526,7 @@ def add_source(
             length=m.len, fill_char="=", width=0, label="upload progress"
         )
 
-        if not quiet:
+        if quiet:
             resp = s.post(
                 url,
                 data=m,

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -521,12 +521,8 @@ def add_source(
 
         file.seek(0)
 
-        m = MultipartEncoder(fields={"file": ("file", file)})
-        prog = click.progressbar(
-            length=m.len, fill_char="=", width=0, label="upload progress"
-        )
-
         if quiet:
+            m = MultipartEncoder(fields={"file": ("file", file)})
             resp = s.post(
                 url,
                 data=m,
@@ -536,6 +532,9 @@ def add_source(
                 },
             )
         else:
+            prog = click.progressbar(
+                length=m.len, fill_char="=", width=0, label="upload progress"
+            )
             with prog:
 
                 def callback(m):

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -520,9 +520,9 @@ def add_source(
             file.write((json.dumps(feature) + "\n").encode("utf-8"))
 
         file.seek(0)
+        m = MultipartEncoder(fields={"file": ("file", file)})
 
         if quiet:
-            m = MultipartEncoder(fields={"file": ("file", file)})
             resp = s.post(
                 url,
                 data=m,


### PR DESCRIPTION
This adds a helpful progress bar with `click.progressbar` while using the `add-source` command. Here's what it looks like, including a progress bar, percentage, and time estimation. 

![Screen Shot 2020-06-08 at 11 50 53 PM](https://user-images.githubusercontent.com/1943001/84115671-4a73e100-a9e3-11ea-9491-053be8ec0087.png)


cc @dianeschulze for review?