### PR TITLE
WIP for multipart

### DIFF
--- a/mapbox_tilesets/errors.py
+++ b/mapbox_tilesets/errors.py
@@ -25,3 +25,10 @@ class TilesetNameError(TilesetsError):
 
     def __init__(self, tileset_id):
         self.message = f"{tileset_id} is not a valid Tileset ID"
+
+
+class SourceUploadFailed(TilesetsError):
+    """Source upload failed"""
+
+    def __init__(self, message):
+        self.message = message


### PR DESCRIPTION
- Sources can consist of up to 10 individual files
- By splitting the input feature into these chunks, we can upload in multiple threads for faster overall upload speed