### PR TITLE
Use request session with user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `--attribution` option to the `create` command
 - Add `delete` command for deleting a tileset
 - Add `tilejson` command
+- Add user-agent header to API requests
 
 # 1.0.1.dev0 (2020-04-07)
 - Fixed http status code for tilesets sources delete so it will no longer error

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -29,7 +29,15 @@ def _get_api():
 
 def _get_session():
     """Get a configured session"""
-    return Session()
+    s = Session()
+    s.headers.update(
+        {
+            "user-agent": "{}/{}".format(
+                mapbox_tilesets.__name__, mapbox_tilesets.__version__
+            )
+        }
+    )
+    return s
 
 
 @click.version_option(version=mapbox_tilesets.__version__, message="%(version)s")

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -1,11 +1,11 @@
 """Tilesets command line interface"""
 import os
 import json
-import requests
 import tempfile
 
 import click
 import cligj
+from requests import Session
 from requests_toolbelt import MultipartEncoder
 
 import mapbox_tilesets
@@ -25,6 +25,11 @@ def _get_token(token=None):
 def _get_api():
     """Get Mapbox tileset API base URL from environment"""
     return os.environ.get("MAPBOX_API", "https://api.mapbox.com")
+
+
+def _get_session():
+    """Get a configured session"""
+    return Session()
 
 
 @click.version_option(version=mapbox_tilesets.__version__, message="%(version)s")
@@ -85,6 +90,7 @@ def create(
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -108,7 +114,7 @@ def create(
             click.echo("Unable to parse attribution JSON")
             click.exit(1)
 
-    r = requests.post(url, json=body)
+    r = s.post(url, json=body)
 
     click.echo(json.dumps(r.json(), indent=indent))
 
@@ -124,10 +130,11 @@ def publish(tileset, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}/publish?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
-    r = requests.post(url)
+    r = s.post(url)
     if r.status_code == 200:
         click.echo(json.dumps(r.json(), indent=indent))
         click.echo(
@@ -174,6 +181,7 @@ def update(
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -191,7 +199,7 @@ def update(
             click.echo("Unable to parse attribution JSON")
             click.exit(1)
 
-    r = requests.patch(url, json=body)
+    r = s.patch(url, json=body)
 
     if r.status_code != 204:
         raise errors.TilesetsError(r.text)
@@ -210,6 +218,7 @@ def delete(tileset, token=None, indent=None, force=None):
 
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
 
     if not force:
         val = click.prompt(
@@ -224,7 +233,7 @@ def delete(tileset, token=None, indent=None, force=None):
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
-    r = requests.delete(url)
+    r = s.delete(url)
     if r.status_code == 200 or r.status_code == 204:
         click.echo("Tileset deleted.")
     else:
@@ -242,10 +251,11 @@ def status(tileset, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}/status?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
-    r = requests.get(url)
+    r = s.get(url)
 
     click.echo(json.dumps(r.json(), indent=indent))
 
@@ -265,6 +275,7 @@ def tilejson(tileset, token=None, indent=None, secure=False):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
 
     # validate tilesets by splitting comma-delimted string
     # and rejoining it
@@ -276,7 +287,7 @@ def tilejson(tileset, token=None, indent=None, secure=False):
     if secure:
         url = url + "&secure"
 
-    r = requests.get(url)
+    r = s.get(url)
     if r.status_code == 200:
         click.echo(json.dumps(r.json(), indent=indent))
     else:
@@ -295,6 +306,7 @@ def jobs(tileset, stage, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}/jobs?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
@@ -303,7 +315,7 @@ def jobs(tileset, stage, token=None, indent=None):
             mapbox_api, tileset, stage, mapbox_token
         )
 
-    r = requests.get(url)
+    r = s.get(url)
 
     click.echo(json.dumps(r.json(), indent=indent))
 
@@ -320,10 +332,11 @@ def job(tileset, job_id, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}/jobs/{2}?access_token={3}".format(
         mapbox_api, tileset, job_id, mapbox_token
     )
-    r = requests.get(url)
+    r = s.get(url)
 
     click.echo(json.dumps(r.json(), indent=indent))
 
@@ -349,10 +362,11 @@ def list(username, verbose, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, username, mapbox_token
     )
-    r = requests.get(url)
+    r = s.get(url)
     if r.status_code == 200:
         if verbose:
             for tileset in r.json():
@@ -375,13 +389,14 @@ def validate_recipe(recipe, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/validateRecipe?access_token={1}".format(
         mapbox_api, mapbox_token
     )
     with open(recipe) as json_recipe:
         recipe_json = json.load(json_recipe)
 
-        r = requests.put(url, json=recipe_json)
+        r = s.put(url, json=recipe_json)
         click.echo(json.dumps(r.json(), indent=indent))
 
 
@@ -396,10 +411,11 @@ def view_recipe(tileset, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}/recipe?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
-    r = requests.get(url)
+    r = s.get(url)
     if r.status_code == 200:
         click.echo(json.dumps(r.json(), indent=indent))
     else:
@@ -418,13 +434,14 @@ def update_recipe(tileset, recipe, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/{1}/recipe?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
     with open(recipe) as json_recipe:
         recipe_json = json.load(json_recipe)
 
-        r = requests.patch(url, json=recipe_json)
+        r = s.patch(url, json=recipe_json)
         if r.status_code == 201 or r.status_code == 204:
             click.echo("Updated recipe.", err=True)
         else:
@@ -460,6 +477,7 @@ def add_source(ctx, username, id, features, no_validation, token=None, indent=No
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = (
         f"{mapbox_api}/tilesets/v1/sources/{username}/{id}?access_token={mapbox_token}"
     )
@@ -472,7 +490,7 @@ def add_source(ctx, username, id, features, no_validation, token=None, indent=No
 
         file.seek(0)
         m = MultipartEncoder(fields={"file": ("file", file)})
-        resp = requests.post(
+        resp = s.post(
             url,
             data=m,
             headers={
@@ -499,10 +517,11 @@ def view_source(username, id, token=None, indent=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/sources/{1}/{2}?access_token={3}".format(
         mapbox_api, username, id, mapbox_token
     )
-    r = requests.get(url)
+    r = s.get(url)
     if r.status_code == 200:
         click.echo(json.dumps(r.json(), indent=indent))
     else:
@@ -533,10 +552,11 @@ def delete_source(username, id, force, token=None):
 
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/sources/{1}/{2}?access_token={3}".format(
         mapbox_api, username, id, mapbox_token
     )
-    r = requests.delete(url)
+    r = s.delete(url)
     if r.status_code == 204:
         click.echo("Source deleted.")
     else:
@@ -553,10 +573,11 @@ def list_sources(username, token=None):
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)
+    s = _get_session()
     url = "{0}/tilesets/v1/sources/{1}?access_token={2}".format(
         mapbox_api, username, mapbox_token
     )
-    r = requests.get(url)
+    r = s.get(url)
     if r.status_code == 200:
         for source in r.json():
             click.echo(source["id"])

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -27,16 +27,12 @@ def _get_api():
     return os.environ.get("MAPBOX_API", "https://api.mapbox.com")
 
 
-def _get_session():
+def _get_session(
+    application=mapbox_tilesets.__name__, version=mapbox_tilesets.__version__
+):
     """Get a configured session"""
     s = Session()
-    s.headers.update(
-        {
-            "user-agent": "{}/{}".format(
-                mapbox_tilesets.__name__, mapbox_tilesets.__version__
-            )
-        }
-    )
+    s.headers.update({"user-agent": "{}/{}".format(application, version)})
     return s
 
 

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -29,7 +29,7 @@ def test_cli_create_missing_name():
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.post")
+@mock.patch("requests.Session.post")
 def test_cli_create_success(mock_request_post, MockResponse):
     runner = CliRunner()
     # sends request to proper endpoints
@@ -86,7 +86,7 @@ def test_cli_create_attribution_json_parse_error():
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.post")
+@mock.patch("requests.Session.post")
 def test_cli_create_success_description(mock_request_post, MockResponse):
     runner = CliRunner()
     # sends request with "description" included
@@ -119,7 +119,7 @@ def test_cli_create_success_description(mock_request_post, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.post")
+@mock.patch("requests.Session.post")
 def test_cli_create_private_invalid(mock_request_post, MockResponse):
     runner = CliRunner()
     # sends request with "description" included
@@ -146,7 +146,7 @@ def test_cli_create_private_invalid(mock_request_post, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.post")
+@mock.patch("requests.Session.post")
 def test_cli_use_token_flag(mock_request_post, MockResponse):
     runner = CliRunner()
     message = {"message": "mock message"}

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -20,7 +20,7 @@ class MockResponse:
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.delete")
+@mock.patch("requests.Session.delete")
 def test_cli_delete(mock_request_delete):
     runner = CliRunner()
 
@@ -38,7 +38,7 @@ def test_cli_delete(mock_request_delete):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.delete")
+@mock.patch("requests.Session.delete")
 def test_cli_delete_prompt_no(mock_request_delete):
     runner = CliRunner()
 
@@ -54,7 +54,7 @@ def test_cli_delete_prompt_no(mock_request_delete):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.delete")
+@mock.patch("requests.Session.delete")
 def test_cli_delete_force(mock_request_delete):
     runner = CliRunner()
 
@@ -69,7 +69,7 @@ def test_cli_delete_force(mock_request_delete):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.delete")
+@mock.patch("requests.Session.delete")
 def test_cli_delete_fail(mock_request_delete):
     runner = CliRunner()
 

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -8,7 +8,7 @@ from mapbox_tilesets.scripts.cli import jobs, job
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_job(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -25,7 +25,7 @@ def test_cli_job(mock_request_get, MockResponse):
 
 # noting for future that this test really is a copy of above
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_job_error(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -41,7 +41,7 @@ def test_cli_job_error(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_jobs_and_stage(mock_request_get, MockResponse):
     """test jobs + stage endpoint"""
     runner = CliRunner()
@@ -58,7 +58,7 @@ def test_cli_jobs_and_stage(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_single_job(mock_request_get, MockResponse):
     """test job endpoint"""
     runner = CliRunner()

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -9,7 +9,7 @@ from mapbox_tilesets.scripts.cli import list
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_list(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -28,7 +28,7 @@ def test_cli_list(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_list_verbose(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -50,7 +50,7 @@ def test_cli_list_verbose(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_list_bad_token(mock_request_get, MockResponse):
     runner = CliRunner()
 

--- a/tests/test_cli_publish.py
+++ b/tests/test_cli_publish.py
@@ -21,7 +21,7 @@ class MockResponse:
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.post")
+@mock.patch("requests.Session.post")
 def test_cli_publish(mock_request_post):
     runner = CliRunner()
 
@@ -39,7 +39,7 @@ def test_cli_publish(mock_request_post):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.post")
+@mock.patch("requests.Session.post")
 def test_cli_publish_use_token_flag(mock_request_post):
     runner = CliRunner()
     mock_request_post.return_value = MockResponse({"message": "mock message"}, 200)

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -14,7 +14,7 @@ from mapbox_tilesets.scripts.cli import (
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.post")
+@mock.patch("requests.Session.post")
 def test_cli_add_source(mock_request_post, MockResponse):
     okay_response = {"id": "mapbox://tileset-source/test-user/hello-world"}
     mock_request_post.return_value = MockResponse(okay_response, status_code=200)
@@ -31,7 +31,7 @@ def test_cli_add_source(mock_request_post, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.post")
+@mock.patch("requests.Session.post")
 def test_cli_add_source_no_validation(mock_request_post, MockResponse):
     error_response = {
         "message": "Invalid file format. Only GeoJSON features are allowed."
@@ -56,7 +56,7 @@ def test_cli_add_source_no_validation(mock_request_post, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_view_source(mock_request_get, MockResponse):
     message = {"id": "mapbox://tileset-source/test-user/hello-world"}
     mock_request_get.return_value = MockResponse(message, status_code=200)
@@ -68,7 +68,7 @@ def test_cli_view_source(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.delete")
+@mock.patch("requests.Session.delete")
 def test_cli_delete_source(mock_request_delete, MockResponse):
     mock_request_delete.return_value = MockResponse("", status_code=204)
     runner = CliRunner()
@@ -86,7 +86,7 @@ def test_cli_delete_source(mock_request_delete, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.delete")
+@mock.patch("requests.Session.delete")
 def test_cli_delete_source_aborted(mock_request_delete, MockResponse):
     mock_request_delete.return_value = MockResponse("", status_code=201)
     runner = CliRunner()
@@ -101,7 +101,7 @@ def test_cli_delete_source_aborted(mock_request_delete, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_view_source_2(mock_request_get, MockResponse):
     message = [
         {"id": "mapbox://tileset-source/test-user/hello-world"},

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -8,7 +8,7 @@ from mapbox_tilesets.scripts.cli import status
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_status(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -24,7 +24,7 @@ def test_cli_status(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_status_use_token_flag(mock_request_get, MockResponse):
     runner = CliRunner()
     message = {"message": "mock message"}

--- a/tests/test_cli_tilejson.py
+++ b/tests/test_cli_tilejson.py
@@ -20,7 +20,7 @@ class MockResponse:
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_tilejson(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -55,7 +55,7 @@ def test_cli_tilejson(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_tilejson_composite(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -69,7 +69,7 @@ def test_cli_tilejson_composite(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_tilejson_secure(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -83,7 +83,7 @@ def test_cli_tilejson_secure(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_tilejson_error(mock_request_get, MockResponse):
     runner = CliRunner()
 

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -21,7 +21,7 @@ class MockResponse:
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.patch")
+@mock.patch("requests.Session.patch")
 def test_cli_patch(mock_request_patch):
     runner = CliRunner()
 
@@ -54,7 +54,7 @@ def test_cli_patch(mock_request_patch):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.patch")
+@mock.patch("requests.Session.patch")
 def test_cli_patch_no_options(mock_request_patch):
     runner = CliRunner()
 

--- a/tests/test_cli_update_recipe.py
+++ b/tests/test_cli_update_recipe.py
@@ -16,7 +16,7 @@ def test_cli_update_recipe_no_recipe():
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.patch")
+@mock.patch("requests.Session.patch")
 def test_cli_update_recipe_201(mock_request_patch, MockResponse):
     runner = CliRunner()
 
@@ -31,7 +31,7 @@ def test_cli_update_recipe_201(mock_request_patch, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.patch")
+@mock.patch("requests.Session.patch")
 def test_cli_update_recipe_204(mock_request_patch, MockResponse):
     runner = CliRunner()
 
@@ -46,7 +46,7 @@ def test_cli_update_recipe_204(mock_request_patch, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.patch")
+@mock.patch("requests.Session.patch")
 def test_cli_update_recipe2(mock_request_patch, MockResponse):
     runner = CliRunner()
 

--- a/tests/test_cli_validate_recipe.py
+++ b/tests/test_cli_validate_recipe.py
@@ -25,7 +25,7 @@ def test_cli_validate_recipe_no_recipe():
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.put")
+@mock.patch("requests.Session.put")
 def test_cli_validate_recipe(mock_request_put, MockResponse):
     runner = CliRunner()
 
@@ -42,7 +42,7 @@ def test_cli_validate_recipe(mock_request_put, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.put")
+@mock.patch("requests.Session.put")
 def test_cli_validate_recipe_use_token_flag(mock_request_put, MockResponse):
     runner = CliRunner()
     message = {"message": "mock message"}

--- a/tests/test_cli_view_recipe.py
+++ b/tests/test_cli_view_recipe.py
@@ -8,7 +8,7 @@ from mapbox_tilesets.scripts.cli import view_recipe
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_view_recipe(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -24,7 +24,7 @@ def test_cli_view_recipe(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_view_recipe_use_token_flag(mock_request_get, MockResponse):
     runner = CliRunner()
     message = {"fake": "recipe_data"}
@@ -39,7 +39,7 @@ def test_cli_view_recipe_use_token_flag(mock_request_get, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.get")
+@mock.patch("requests.Session.get")
 def test_cli_view_recipe_raises(mock_request_get, MockResponse):
     runner = CliRunner()
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,7 @@
+from mapbox_tilesets.scripts.cli import _get_session
+
+
+def test_get_session():
+    s = _get_session("my_application", "1.0.0")
+    assert "user-agent" in s.headers
+    assert s.headers["user-agent"] == "my_application/1.0.0"


### PR DESCRIPTION
Sends HTTP requests via a session that includes a user-agent header on every request.

The user-agent is `{application}/{version}`, e.g. `mapbox_tilesets/1.0.1`

TODO:
- [x] Update Changelog