### PR TITLE
Add list options type, visibility, sortby, and limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Pin pytest version
+- Add `--type`, `--visibility`, `--sortby`, and `--limit` options to `list` command
 
 # 1.1.0.dev0 (2020-06-11)
 - `update-recipe` command handles 204 status code in addition to 201 and no longer prints response text

--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ Check all jobs associated with a tileset. You can filter jobs by a particular `s
 tilesets jobs <tileset_id> --stage=processing
 ```
 
-- --stage: Filter by the stage of jobs. (Optional.)
+Flags:
+
+* `--stage` [optional]: filter by the stage of jobs
 
 ### list
 
@@ -257,6 +259,8 @@ List all tilesets for an account. Just lists tileset IDs by default. Use the `--
 ```shell
 tilesets list <username>
 ```
+
+Flags:
 
 * `--type [vector|raster]` [optional]: filter results by tileset type
 * `--visibility [public|private]` [optional]: filter results by visibility
@@ -274,6 +278,6 @@ A TileJSON document, according to the [specification](https://github.com/mapbox/
 tilesets tilejson <tileset_id>
 ```
 
-Flags
+Flags:
 
 * `--secure`: By default, resource URLs in the retrieved TileJSON (such as in the "tiles" array) will use the HTTP scheme. Include this query parameter in your request to receive HTTPS resource URLs instead.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ tilesets list <username>
 * `--type [vector|raster]` [optional]: filter results by tileset type
 * `--visibility [public|private]` [optional]: filter results by visibility
 * `--sortby [created|modified]` [optional]: sort results by their `created` or `modified` timestamps
+* `--limit [1-500]` [optional]: the maximum number of results to return, from 1 to 500. The default is 100.
 * `--verbose` [optional]: will list out the entire response object from the API
 
 ### tilejson

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ List all tilesets for an account. Just lists tileset IDs by default. Use the `--
 tilesets list <username>
 ```
 
+* `--type [vector|raster]` [optional]: filter results by tileset type
 * `--visibility [public|private]` [optional]: filter results by visibility
 * `--verbose` [optional]: will list out the entire response object from the API
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ tilesets list <username>
 
 * `--type [vector|raster]` [optional]: filter results by tileset type
 * `--visibility [public|private]` [optional]: filter results by visibility
+* `--sortby [created|modified]` [optional]: sort results by their `created` or `modified` timestamps
 * `--verbose` [optional]: will list out the entire response object from the API
 
 ### tilejson

--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ List all tilesets for an account. Just lists tileset IDs by default. Use the `--
 tilesets list <username>
 ```
 
-- --verbose: will list out the entire response object from the API
+* `--visibility [public|private]` [optional]: filter results by visibility
+* `--verbose` [optional]: will list out the entire response object from the API
 
 ### tilejson
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -372,10 +372,24 @@ def job(tileset, job_id, token=None, indent=None):
     type=click.Choice(["created", "modified"]),
     help="Sort the results by their created or modified timestamps",
 )
+@click.option(
+    "--limit",
+    required=False,
+    type=click.IntRange(1, 500),
+    default=100,
+    help="The maximum number of results to return, from 1 to 500 (default 100)",
+)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
 def list(
-    username, verbose, type=None, visibility=None, sortby=None, token=None, indent=None
+    username,
+    verbose,
+    type=None,
+    visibility=None,
+    sortby=None,
+    limit=None,
+    token=None,
+    indent=None,
 ):
     """List all tilesets for an account.
     By default the response is a simple list of tileset IDs.
@@ -390,6 +404,7 @@ def list(
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, username, mapbox_token
     )
+    url = "{0}&limit={1}".format(url, limit) if limit else url
     url = "{0}&type={1}".format(url, type) if type else url
     url = "{0}&visibility={1}".format(url, visibility) if visibility else url
     url = "{0}&sortby={1}".format(url, sortby) if sortby else url

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -354,9 +354,15 @@ def job(tileset, job_id, token=None, indent=None):
     is_flag=True,
     help="Will print all tileset information",
 )
+@click.option(
+    "--visibility",
+    required=False,
+    type=click.Choice(["public", "private"]),
+    help="Filter results by visibility",
+)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
-def list(username, verbose, token=None, indent=None):
+def list(username, verbose, visibility=None, token=None, indent=None):
     """List all tilesets for an account.
     By default the response is a simple list of tileset IDs.
     If you would like an array of all tileset's information,
@@ -370,6 +376,7 @@ def list(username, verbose, token=None, indent=None):
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, username, mapbox_token
     )
+    url = "{0}&visibility={1}".format(url, visibility) if visibility else url
     r = s.get(url)
     if r.status_code == 200:
         if verbose:

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -366,9 +366,17 @@ def job(tileset, job_id, token=None, indent=None):
     type=click.Choice(["public", "private"]),
     help="Filter results by visibility",
 )
+@click.option(
+    "--sortby",
+    required=False,
+    type=click.Choice(["created", "modified"]),
+    help="Sort the results by their created or modified timestamps",
+)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
-def list(username, verbose, type=None, visibility=None, token=None, indent=None):
+def list(
+    username, verbose, type=None, visibility=None, sortby=None, token=None, indent=None
+):
     """List all tilesets for an account.
     By default the response is a simple list of tileset IDs.
     If you would like an array of all tileset's information,
@@ -384,6 +392,7 @@ def list(username, verbose, type=None, visibility=None, token=None, indent=None)
     )
     url = "{0}&type={1}".format(url, type) if type else url
     url = "{0}&visibility={1}".format(url, visibility) if visibility else url
+    url = "{0}&sortby={1}".format(url, sortby) if sortby else url
     r = s.get(url)
     if r.status_code == 200:
         if verbose:

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -355,6 +355,12 @@ def job(tileset, job_id, token=None, indent=None):
     help="Will print all tileset information",
 )
 @click.option(
+    "--type",
+    required=False,
+    type=click.Choice(["vector", "raster"]),
+    help="Filter results by tileset type",
+)
+@click.option(
     "--visibility",
     required=False,
     type=click.Choice(["public", "private"]),
@@ -362,7 +368,7 @@ def job(tileset, job_id, token=None, indent=None):
 )
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
-def list(username, verbose, visibility=None, token=None, indent=None):
+def list(username, verbose, type=None, visibility=None, token=None, indent=None):
     """List all tilesets for an account.
     By default the response is a simple list of tileset IDs.
     If you would like an array of all tileset's information,
@@ -376,6 +382,7 @@ def list(username, verbose, visibility=None, token=None, indent=None):
     url = "{0}/tilesets/v1/{1}?access_token={2}".format(
         mapbox_api, username, mapbox_token
     )
+    url = "{0}&type={1}".format(url, type) if type else url
     url = "{0}&visibility={1}".format(url, visibility) if visibility else url
     r = s.get(url)
     if r.status_code == 200:

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -63,3 +63,41 @@ def test_cli_list_bad_token(mock_request_get, MockResponse):
     )
     assert result.exit_code == 1
     assert result.exception
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_visibility_public(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {"id": "test.tileset-1", "something": "beep"},
+        {"id": "test.tileset-2", "something": "boop"},
+    ]
+
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(list, ["test", "--visibility", "public"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&visibility=public"
+    )
+    assert result.exit_code == 0
+    assert result.output == """test.tileset-1\ntest.tileset-2\n"""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_visibility_private(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {"id": "test.tileset-1", "something": "beep"},
+        {"id": "test.tileset-2", "something": "boop"},
+    ]
+
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(list, ["test", "--visibility", "private"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&visibility=private"
+    )
+    assert result.exit_code == 0
+    assert result.output == """test.tileset-1\ntest.tileset-2\n"""

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -21,7 +21,7 @@ def test_cli_list(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -40,7 +40,7 @@ def test_cli_list_verbose(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--verbose"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100"
     )
     assert result.exit_code == 0
 
@@ -59,7 +59,7 @@ def test_cli_list_bad_token(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message, status_code=404)
     result = runner.invoke(list, ["test"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100"
     )
     assert result.exit_code == 1
     assert result.exception
@@ -78,7 +78,7 @@ def test_cli_list_type_vector(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--type", "vector"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&type=vector"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&type=vector"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -97,7 +97,7 @@ def test_cli_list_type_raster(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--type", "raster"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&type=raster"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&type=raster"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -116,7 +116,7 @@ def test_cli_list_visibility_public(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--visibility", "public"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&visibility=public"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&visibility=public"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -135,7 +135,7 @@ def test_cli_list_visibility_private(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--visibility", "private"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&visibility=private"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&visibility=private"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -154,7 +154,7 @@ def test_cli_list_sortby_created(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--sortby", "created"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&sortby=created"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&sortby=created"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -173,10 +173,38 @@ def test_cli_list_sortby_modified(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--sortby", "modified"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&sortby=modified"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&sortby=modified"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_limit_10(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {"id": "test.tileset-1", "something": "beep"},
+        {"id": "test.tileset-2", "something": "boop"},
+    ]
+
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(list, ["test", "--limit", "10"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=10"
+    )
+    assert result.exit_code == 0
+    assert result.output == """test.tileset-1\ntest.tileset-2\n"""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_limit_out_of_range(mock_request_get):
+    runner = CliRunner()
+    result = runner.invoke(list, ["test", "--limit", "0"])
+    mock_request_get.assert_not_called()
+    assert result.exit_code == 2
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -192,10 +220,20 @@ def test_cli_list_options(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(
         list,
-        ["test", "--type", "vector", "--visibility", "private", "--sortby", "created"],
+        [
+            "test",
+            "--limit",
+            "10",
+            "--type",
+            "vector",
+            "--visibility",
+            "private",
+            "--sortby",
+            "created",
+        ],
     )
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&type=vector&visibility=private&sortby=created"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=10&type=vector&visibility=private&sortby=created"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -67,6 +67,44 @@ def test_cli_list_bad_token(mock_request_get, MockResponse):
 
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.Session.get")
+def test_cli_list_type_vector(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {"id": "test.tileset-1", "something": "beep"},
+        {"id": "test.tileset-2", "something": "boop"},
+    ]
+
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(list, ["test", "--type", "vector"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&type=vector"
+    )
+    assert result.exit_code == 0
+    assert result.output == """test.tileset-1\ntest.tileset-2\n"""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_type_raster(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {"id": "test.tileset-1", "something": "beep"},
+        {"id": "test.tileset-2", "something": "boop"},
+    ]
+
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(list, ["test", "--type", "raster"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&type=raster"
+    )
+    assert result.exit_code == 0
+    assert result.output == """test.tileset-1\ntest.tileset-2\n"""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
 def test_cli_list_visibility_public(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -98,6 +136,27 @@ def test_cli_list_visibility_private(mock_request_get, MockResponse):
     result = runner.invoke(list, ["test", "--visibility", "private"])
     mock_request_get.assert_called_with(
         "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&visibility=private"
+    )
+    assert result.exit_code == 0
+    assert result.output == """test.tileset-1\ntest.tileset-2\n"""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_options(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {"id": "test.tileset-1", "something": "beep"},
+        {"id": "test.tileset-2", "something": "boop"},
+    ]
+
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(
+        list, ["test", "--type", "vector", "--visibility", "private"]
+    )
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&type=vector&visibility=private"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -143,6 +143,44 @@ def test_cli_list_visibility_private(mock_request_get, MockResponse):
 
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.Session.get")
+def test_cli_list_sortby_created(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {"id": "test.tileset-1", "something": "beep"},
+        {"id": "test.tileset-2", "something": "boop"},
+    ]
+
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(list, ["test", "--sortby", "created"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&sortby=created"
+    )
+    assert result.exit_code == 0
+    assert result.output == """test.tileset-1\ntest.tileset-2\n"""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_sortby_modified(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {"id": "test.tileset-1", "something": "beep"},
+        {"id": "test.tileset-2", "something": "boop"},
+    ]
+
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(list, ["test", "--sortby", "modified"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&sortby=modified"
+    )
+    assert result.exit_code == 0
+    assert result.output == """test.tileset-1\ntest.tileset-2\n"""
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
 def test_cli_list_options(mock_request_get, MockResponse):
     runner = CliRunner()
 
@@ -153,10 +191,11 @@ def test_cli_list_options(mock_request_get, MockResponse):
 
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(
-        list, ["test", "--type", "vector", "--visibility", "private"]
+        list,
+        ["test", "--type", "vector", "--visibility", "private", "--sortby", "created"],
     )
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&type=vector&visibility=private"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&type=vector&visibility=private&sortby=created"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""


### PR DESCRIPTION
Adds 4 new options to the `tilesets list` command:
- `--type [vector|raster]`
- `--visibility [public|private]`
- `--sortby [created|modified]`
- `--limit [1-500]` (default 100)

Also makes a few changes to README.md to consistently format the flags for each command.

TODO:
- [x] Update CHANGELOG.md