### PR TITLE
travis installs latest pip and pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
 python:
   - '3.6'
+before_install:
+  - python --version
+  - pip install -U pip
+  - pip install -U pytest
+  - pytest --version
 install:
   - pip install -r requirements.txt -e .[test]
 script:
-  - python --version
-  - pytest --version
   - pre-commit run --all-files
   - pytest --cov --cov-config=.coveragerc
 after_script:


### PR DESCRIPTION
Travis tests fail when the pytest it installs isn't the latest version. This PR adds a `before_install` step to upgrade pip and pytest so they are always the latest version and we avoid these failures.