### PR TITLE
Pin pytest to v4.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Pin pytest version
+
 # 1.1.0.dev0 (2020-06-11)
 - `update-recipe` command handles 204 status code in addition to 201 and no longer prints response text
 - Add `update` command for updating `--name`, `--description`, `--privacy`, and `--attribution` of a tileset

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     extras_require={
-        "test": ["pytest==4.3.1", "pytest-cov", "pre-commit", "black", "pep8"]
+        "test": ["pytest==4.6.11", "pytest-cov", "pre-commit", "black", "pep8"]
     },
     entry_points="""
       [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     extras_require={
-        "test": ["pytest>=3.6.0", "pytest-cov", "pre-commit", "black", "pep8"]
+        "test": ["pytest==4.3.1", "pytest-cov", "pre-commit", "black", "pep8"]
     },
     entry_points="""
       [console_scripts]


### PR DESCRIPTION
Pins pytest to v4.6.11 to avoid travis failures due to version conflicts and to make sure the version is consistent between all runs and environments.