### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 [![Build Status](https://travis-ci.com/mapbox/tilesets-cli.svg?token=wqR3RcWUEprcQ1ttsgiP&branch=master)](https://travis-ci.com/mapbox/tilesets-cli) [![codecov](https://codecov.io/gh/mapbox/tilesets-cli/branch/master/graph/badge.svg?token=YBTKyc2o3j)](https://codecov.io/gh/mapbox/tilesets-cli)
 
-CLI for interacting with and preparing data for [Mapbox Tilesets API](https://docs.mapbox.com/api/maps/#tilesets).
+CLI for interacting with and preparing data for the [Mapbox Tiling Service](https://docs.mapbox.com/mapbox-tiling-service/overview/).
+
+📚 If you have a question that isn't answered here, please refer to the complete [Mapbox Tiling Service documentation](https://docs.mapbox.com/mapbox-tiling-service/overview/).
+
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Creates a brand new, empty tileset with a recipe passed in from your local files
 ```shell
 tilesets create <tileset_id> --recipe /path/to/recipe.json --name "My neat tileset"
 ```
+The `tileset_id` is in the form of `username.handle` - for example "mapbox.neat-tileset". The handle may only include "-" or "\_" special characters and must be 32 characters or fewer.
+
 
 Flags:
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Example error output:
 
 Update the Recipe JSON for a tileset. Performs a server-side validation of the new document.
 
+This command only supports tilesets created with the [Mapbox Tiling Service](https://docs.mapbox.com/mapbox-tiling-service/overview/).
+
 ```shell
 tilesets update-recipe <tileset_id> /path/to/recipe.json
 ```
@@ -188,6 +190,8 @@ Flags:
 ### publish
 
 Queues a tiling _job_ using the recipe provided. Use to publish a new tileset or update an existing one. Returns a job ID for progress tracking.
+
+This command only supports tilesets created with the [Mapbox Tiling Service](https://docs.mapbox.com/mapbox-tiling-service/overview/).
 
 ```
 tilesets publish <tileset_id>
@@ -236,6 +240,8 @@ tilesets status <tileset_id>
 
 Retrieve a single job for a tileset.
 
+This command only supports tilesets created with the [Mapbox Tiling Service](https://docs.mapbox.com/mapbox-tiling-service/overview/).
+
 ```shell
 tilesets job <tileset_id> <job_id>
 ```
@@ -246,6 +252,7 @@ tilesets job <tileset_id> <job_id>
 
 Check all jobs associated with a tileset. You can filter jobs by a particular `stage` - processing, queued, success, or failed.
 
+This command only supports tilesets created with the [Mapbox Tiling Service](https://docs.mapbox.com/mapbox-tiling-service/overview/).
 
 ```shell
 tilesets jobs <tileset_id> --stage=processing

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Flags:
 * `--recipe` or `-r` [required]: path to your Recipe JSON document
 * `--name` or `-n` [required]: human-readable name of your tileset. (If your tileset_id is user.my_amazing_tileset, you might want your `name` field to be "My Amazing Tileset".)
 * `--description` or `-d`: description of your tileset
-* `--privacy` or `-p`: Set the privacy of the tileset. Allowed values are `private` and `public`. If not provided, will default to your plan level on Mapbox.com. Pay-As-You-Go plans only support public maps.
+* `--privacy` or `-p`: Set the privacy of the tileset. Allowed values are `private` and `public`. By default, new tilesets are private.
 * `--attribution` or `-a` [optional]: set tileset attribution. Must be a JSON string, specifically an array of attribution objects, each with `text` and `link` keys. Limited to three attribution objects, 80 characters maximum combined across all text values, and 1000 characters maximum combined across all link values.
 
 ### publish

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -90,7 +90,7 @@ def create(
     $ tilesets create <tileset_id>
 
     <tileset_id> is in the form of username.handle - for example "mapbox.neat-tileset".
-    The handle may only include "-" or "_" special characters.
+    The handle may only include "-" or "_" special characters and must be 32 characters or fewer.
     """
     mapbox_api = _get_api()
     mapbox_token = _get_token(token)

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -130,6 +130,8 @@ def create(
 def publish(tileset, token=None, indent=None):
     """Publish your tileset.
 
+    Only supports tilesets created with the Mapbox Tiling Service.
+
     tilesets publish <tileset_id>
     """
     mapbox_api = _get_api()
@@ -306,6 +308,8 @@ def tilejson(tileset, token=None, indent=None, secure=False):
 def jobs(tileset, stage, token=None, indent=None):
     """View all jobs for a particular tileset.
 
+    Only supports tilesets created with the Mapbox Tiling Service.
+
     tilesets jobs <tileset_id>
     """
     mapbox_api = _get_api()
@@ -331,6 +335,8 @@ def jobs(tileset, stage, token=None, indent=None):
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
 def job(tileset, job_id, token=None, indent=None):
     """View a single job for a particular tileset.
+
+    Only supports tilesets created with the Mapbox Tiling Service.
 
     tilesets job <tileset_id> <job_id>
     """
@@ -471,6 +477,8 @@ def view_recipe(tileset, token=None, indent=None):
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
 def update_recipe(tileset, recipe, token=None, indent=None):
     """Update a Recipe JSON document for a particular tileset
+
+    Only supports tilesets created with the Mapbox Tiling Service.
 
     tilesets update-recipe <tileset_id> <path_to_recipe>
     """

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -10,7 +10,7 @@ def validate_tileset_id(tileset_id):
     ----------
     tileset_id: str
         tileset_id of the form {account}.{tileset}
-        - account and tileset should each be under 32 characters
+        - account and tileset should each be 32 characters or fewer.
 
     Returns
     -------


### PR DESCRIPTION
## Address feedback from:
- https://github.com/mapbox/tilesets-cli/issues/48
- https://github.com/mapbox/tilesets-cli/issues/37
- https://github.com/mapbox/tilesets-cli/issues/35
- https://github.com/mapbox/tilesets-cli/issues/33


## Changes
- Explicitly link readme to MTS overview docs for more info
- Update the readme info on default tileset visibility
- In the readme and docstrings, identify the commands that only support MTS tilesets
- Make the tileset id format rules consistent between the readme, function docstrings, and validator docstring