### PR TITLE
TilesetNameError message includes both tileset id and description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - Pin pytest version
 - Add `--type`, `--visibility`, `--sortby`, and `--limit` options to `list` command
+- Make TilesetNameError message more descriptive
 
 # 1.1.0.dev0 (2020-06-11)
 - `update-recipe` command handles 204 status code in addition to 201 and no longer prints response text

--- a/mapbox_tilesets/errors.py
+++ b/mapbox_tilesets/errors.py
@@ -24,4 +24,8 @@ class TilesetNameError(TilesetsError):
     """
 
     def __init__(self, tileset_id):
-        self.message = f"{tileset_id} is not a valid Tileset ID"
+        self.tileset_id = tileset_id
+        self.message = "Invalid Tileset ID"
+
+    def __str__(self):
+        return f"{self.tileset_id} -> {self.message}"

--- a/mapbox_tilesets/errors.py
+++ b/mapbox_tilesets/errors.py
@@ -28,4 +28,6 @@ class TilesetNameError(TilesetsError):
         self.message = "Invalid Tileset ID"
 
     def __str__(self):
-        return f"{self.tileset_id} -> {self.message}"
+        return "{tileset_id} -> {message}".format(
+            tileset_id=self.tileset_id, message=self.message
+        )

--- a/tests/test_cli_tilejson.py
+++ b/tests/test_cli_tilejson.py
@@ -105,4 +105,4 @@ def test_cli_tilejson_invalid_tileset_id():
     result = runner.invoke(tilejson, ["invalid@@id"])
     assert result.exit_code == 1
     assert isinstance(result.exception, TilesetNameError)
-    assert str(result.exception) == "invalid@@id"
+    assert "invalid@@id" in str(result.exception)


### PR DESCRIPTION
`TilesetNameError` is intended to log a message like `{tileset_id} is not a valid Tileset ID`, but it actually only logs the tileset ID.

This PR defines the `__str__()` function on `TilesetNameError` so the message can include both the tileset ID and the description. 

**Before:**
```shell
$ tilesets create invalid -r recipe.json -n "invalid id"
Traceback (most recent call last):
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/bin/tilesets", line 11, in <module>
    load_entry_point('mapbox-tilesets', 'console_scripts', 'tilesets')()
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/dianeschulze/work/mapbox/tilesets-cli/mapbox_tilesets/scripts/cli.py", line 108, in create
    raise errors.TilesetNameError(tileset)
mapbox_tilesets.errors.TilesetNameError: invalid
```

**After:**
```shell
$ tilesets create invalid -r recipe.json -n "invalid id"
Traceback (most recent call last):
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/bin/tilesets", line 11, in <module>
    load_entry_point('mapbox-tilesets', 'console_scripts', 'tilesets')()
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dianeschulze/.virtualenvs/tilesets-cli/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/dianeschulze/work/mapbox/tilesets-cli/mapbox_tilesets/scripts/cli.py", line 108, in create
    raise errors.TilesetNameError(tileset)
mapbox_tilesets.errors.TilesetNameError: invalid -> Invalid Tileset ID
```

TODO:
- [x] Update changelog