### PR TITLE
Add tilesets:list scope to token requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CLI for interacting with and preparing data for the [Mapbox Tiling Service](http
 
 #### Mapbox Access Tokens
 
-In order to use the tilesets endpoints, you need a Mapbox Access Token with `tilesets:write` and `tilesets:read` scopes. This is a secret token, so do not share it publicly!
+In order to use the tilesets endpoints, you need a Mapbox Access Token with `tilesets:write`, `tilesets:read`, and `tilesets:list` scopes. This is a secret token, so do not share it publicly!
 
 You can either pass the Mapbox access token to each command with the `--token` flag or export it as an environment variable. Acceptable values are:
 


### PR DESCRIPTION
Some commands require `tilesets:list` scopes, including the `list` command.

This updates the README to add `tilesets:list` to the list of token scopes required.