### PR TITLE
Add limit option to jobs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `--type`, `--visibility`, `--sortby`, and `--limit` options to `list` command
 - Make TilesetNameError message more descriptive
 - Fail early if no access_token is provided
+- Add `--limit` option to `jobs` command
 
 # 1.1.0.dev0 (2020-06-11)
 - `update-recipe` command handles 204 status code in addition to 201 and no longer prints response text

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ tilesets jobs <tileset_id> --stage=processing
 Flags:
 
 * `--stage` [optional]: filter by the stage of jobs
+* `--limit [1-500]` [optional]: the maximum number of results to return, from 1 to 500. The default is 100.
 
 ### list
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -279,7 +279,7 @@ def tilejson(tileset, token=None, indent=None, secure=False):
 @click.option("--stage", "-s", required=False, type=str, help="job stage")
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
-def jobs(tileset, stage, token=None, indent=None):
+def jobs(tileset, stage=None, token=None, indent=None):
     """View all jobs for a particular tileset.
 
     Only supports tilesets created with the Mapbox Tiling Service.
@@ -292,13 +292,8 @@ def jobs(tileset, stage, token=None, indent=None):
     url = "{0}/tilesets/v1/{1}/jobs?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
-    if stage:
-        url = "{0}/tilesets/v1/{1}/jobs?stage={2}&access_token={3}".format(
-            mapbox_api, tileset, stage, mapbox_token
-        )
-
+    url = "{0}&stage={1}".format(url, stage) if stage else url
     r = s.get(url)
-
     click.echo(json.dumps(r.json(), indent=indent))
 
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -277,9 +277,16 @@ def tilejson(tileset, token=None, indent=None, secure=False):
 @cli.command("jobs")
 @click.argument("tileset", required=True, type=str)
 @click.option("--stage", "-s", required=False, type=str, help="job stage")
+@click.option(
+    "--limit",
+    required=False,
+    type=click.IntRange(1, 500),
+    default=100,
+    help="The maximum number of results to return, from 1 to 500 (default 100)",
+)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
-def jobs(tileset, stage=None, token=None, indent=None):
+def jobs(tileset, stage=None, limit=None, token=None, indent=None):
     """View all jobs for a particular tileset.
 
     Only supports tilesets created with the Mapbox Tiling Service.
@@ -292,6 +299,7 @@ def jobs(tileset, stage=None, token=None, indent=None):
     url = "{0}/tilesets/v1/{1}/jobs?access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
+    url = "{0}&limit={1}".format(url, limit) if limit else url
     url = "{0}&stage={1}".format(url, stage) if stage else url
     r = s.get(url)
     click.echo(json.dumps(r.json(), indent=indent))

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -17,7 +17,7 @@ def test_cli_job(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(jobs, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=100"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message
@@ -34,7 +34,7 @@ def test_cli_job_error(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message, status_code=404)
     result = runner.invoke(jobs, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=100"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message
@@ -51,7 +51,49 @@ def test_cli_jobs_and_stage(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(jobs, ["test.id", "--stage", "complete"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&stage=complete"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=100&stage=complete"
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.output) == message
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_jobs_limit(mock_request_get, MockResponse):
+    """test jobs + stage endpoint"""
+    runner = CliRunner()
+
+    # sends expected request
+    message = {"message": "mock message"}
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(jobs, ["test.id", "--limit", "10"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=10"
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_jobs_limit_out_of_range(mock_request_get):
+    runner = CliRunner()
+    result = runner.invoke(jobs, ["test.id", "--limit", "0"])
+    mock_request_get.assert_not_called()
+    assert result.exit_code == 2
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_jobs_stage_and_limit(mock_request_get, MockResponse):
+    """test jobs + stage endpoint"""
+    runner = CliRunner()
+
+    # sends expected request
+    message = {"message": "mock message"}
+    mock_request_get.return_value = MockResponse(message)
+    result = runner.invoke(jobs, ["test.id", "--stage", "complete", "--limit", "10"])
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=10&stage=complete"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -51,7 +51,7 @@ def test_cli_jobs_and_stage(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(jobs, ["test.id", "--stage", "complete"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?stage=complete&access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&stage=complete"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -49,9 +49,9 @@ def test_cli_jobs_and_stage(mock_request_get, MockResponse):
     # sends expected request
     message = {"message": "mock message"}
     mock_request_get.return_value = MockResponse(message)
-    result = runner.invoke(jobs, ["test.id", "--stage", "complete"])
+    result = runner.invoke(jobs, ["test.id", "--stage", "success"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=100&stage=complete"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=100&stage=success"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message
@@ -91,9 +91,9 @@ def test_cli_jobs_stage_and_limit(mock_request_get, MockResponse):
     # sends expected request
     message = {"message": "mock message"}
     mock_request_get.return_value = MockResponse(message)
-    result = runner.invoke(jobs, ["test.id", "--stage", "complete", "--limit", "10"])
+    result = runner.invoke(jobs, ["test.id", "--stage", "success", "--limit", "10"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=10&stage=complete"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=10&stage=success"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message


### PR DESCRIPTION
Adds an optional `--limit` flag to the `tilesets jobs` command. This flag accepts values from 1 to 500 and defaults to 100.

Relevant API docs: https://docs.mapbox.com/api/maps/#list-information-about-all-jobs-for-a-tileset

Helptext:
```shell
$ tilesets jobs --help
Usage: tilesets jobs [OPTIONS] TILESET

  View all jobs for a particular tileset.

  Only supports tilesets created with the Mapbox Tiling Service.

  tilesets jobs <tileset_id>

Options:
  -s, --stage TEXT       job stage
  --limit INTEGER RANGE  The maximum number of results to return, from 1 to
                         500 (default 100)
  -t, --token TEXT       Mapbox access token
  --indent INTEGER       Indent for JSON output
  --help                 Show this message and exit.
```

Usage:
```shell
$ tilesets jobs username.tileset --limit 4
$ tilesets jobs username.tileset --stage success --limit 1
```