### PR TITLE
Send compact JSON with `add-source`

### DIFF
--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -517,7 +517,7 @@ def add_source(
             if not no_validation:
                 utils.validate_geojson(feature)
 
-            file.write((json.dumps(feature) + "\n").encode("utf-8"))
+            file.write((json.dumps(feature, separators=(',', ':')) + "\n").encode("utf-8"))
 
         file.seek(0)
         m = MultipartEncoder(fields={"file": ("file", file)})

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -517,7 +517,9 @@ def add_source(
             if not no_validation:
                 utils.validate_geojson(feature)
 
-            file.write((json.dumps(feature, separators=(',', ':')) + "\n").encode("utf-8"))
+            file.write(
+                (json.dumps(feature, separators=(",", ":")) + "\n").encode("utf-8")
+            )
 
         file.seek(0)
         m = MultipartEncoder(fields={"file": ("file", file)})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def MockResponse():
 
 class _MockMultipartEncoding:
     def __init__(self):
-        self.content_type = 'whatever'
+        self.content_type = "whatever"
         self.len = 8
 
     def MockMultipartEncoding(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,3 +30,17 @@ class _MockResponse:
 @pytest.fixture
 def MockResponse():
     return _MockResponse
+
+
+class _MockMultipartEncoding:
+    def __init__(self):
+        self.content_type = 'whatever'
+        self.len = 8
+
+    def MockMultipartEncoding(self):
+        return self
+
+
+@pytest.fixture
+def MockMultipartEncoding():
+    return _MockMultipartEncoding

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -33,7 +33,7 @@ def test_cli_add_source(mock_request_post, MockResponse):
     expected_json = """{"type":"Feature","geometry":{"type":"Point","coordinates":[125.6, 10.1]},"properties":{"name":"Dinagat Islands"}}"""
 
     # the length of the data sent is the length of the compact string, plus 140 bytes of header
-    assert mock_request_post.call_args.kwargs["data"].len == len(expected_json) + 140
+    assert mock_request_post.call_args[1]["data"].len == len(expected_json) + 140
 
 
 def test_cli_add_source_no_token():

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -39,10 +39,6 @@ def test_cli_add_source(mock_request_post, mock_multipart_encoder_monitor, mock_
         == """{"id": "mapbox://tileset-source/test-user/hello-world"}\n"""
     )
 
-    # the length of the data sent is the length of the compact string, plus 140 bytes of header
-    # assert mock_multipart_encoder.call_args == "hello"
-    # assert mock_request_post.call_args[1]["data"].len == len(expected_json) + 140
-
 
 def test_cli_add_source_no_token():
     if "MAPBOX_ACCESS_TOKEN" in os.environ:

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -30,6 +30,11 @@ def test_cli_add_source(mock_request_post, MockResponse):
         == """{"id": "mapbox://tileset-source/test-user/hello-world"}\n"""
     )
 
+    expected_json = """{"type":"Feature","geometry":{"type":"Point","coordinates":[125.6, 10.1]},"properties":{"name":"Dinagat Islands"}}"""
+
+    # the length of the data sent is the length of the compact string, plus 140 bytes of header
+    assert mock_request_post.call_args.kwargs["data"].len == len(expected_json) + 140
+
 
 def test_cli_add_source_no_token():
     if "MAPBOX_ACCESS_TOKEN" in os.environ:

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -18,14 +18,22 @@ from mapbox_tilesets.scripts.cli import (
 @mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoder")
 @mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoderMonitor")
 @mock.patch("requests.Session.post")
-def test_cli_add_source(mock_request_post, mock_multipart_encoder_monitor, mock_multipart_encoder, MockResponse, MockMultipartEncoding):
+def test_cli_add_source(
+    mock_request_post,
+    mock_multipart_encoder_monitor,
+    mock_multipart_encoder,
+    MockResponse,
+    MockMultipartEncoding,
+):
     okay_response = {"id": "mapbox://tileset-source/test-user/hello-world"}
     mock_request_post.return_value = MockResponse(okay_response, status_code=200)
 
     expected_json = b'{"type":"Feature","geometry":{"type":"Point","coordinates":[125.6,10.1]},"properties":{"name":"Dinagat Islands"}}\n'
+
     def side_effect(fields):
-        assert fields['file'][1].read() == expected_json
+        assert fields["file"][1].read() == expected_json
         return MockMultipartEncoding()
+
     mock_multipart_encoder.side_effect = side_effect
 
     runner = CliRunner()


### PR DESCRIPTION
Per #91, reduce the bandwidth used by `add-source` by making the JSON of the feature compact.

## Acceptance criteria

- Prove that the file is smaller when written to the API
- I'm not sure how to test this. I see there's an `assert_called_with` method for the mocked POST endpoint, but it doesn't seem to work well with comparing multi-part uploaded files. Any advice on this?