### PR TITLE
Add upload-source command with --replace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ export MAPBOX_ACCESS_TOKEN=my.token
 # Commands
 
 * Tileset Sources
-  * [`upload-source`](#add-source)
-  * *deprecated* [`add-source`](#add-source)
+  * [`upload-source`](#upload-source)
+  * *deprecated* [`add-source`](#deprecated-add-source)
   * [`validate-source`](#validate-source)
   * [`view-source`](#view-source)
   * [`list-sources`](#list-source)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ export MAPBOX_ACCESS_TOKEN=my.token
 # Commands
 
 * Tileset Sources
-  * [`add-source`](#add-source)
+  * [`upload-source`](#add-source)
+  * *deprecated* [`add-source`](#add-source)
   * [`validate-source`](#validate-source)
   * [`view-source`](#view-source)
   * [`list-sources`](#list-source)
@@ -56,7 +57,37 @@ export MAPBOX_ACCESS_TOKEN=my.token
   * [`list`](#list)
   * [`tilejson`](#tilejson)
 
-### add-source
+### upload-source
+
+```shell
+tilesets upload-source <username> <id> <file>
+```
+
+Uploads GeoJSON files to a source for tiling. Accepts line-delimited GeoJSON or GeoJSON feature collections as files or via `stdin`. The CLI automatically converts data to line-delimited GeoJSON prior to uploading. Can be used to add data to a source or to replace all of the data in a source with the `--replace` flag.
+
+Flags:
+
+* `--no-validation` [optional]: do not validate source data locally before uploading
+* `--replace` [optional]: delete all existing source data and replace with data from the file
+* `--quiet` [optional]: do not display an upload progress bar
+
+Usage
+
+```shell
+# single file
+tilesets upload-source <username> <id> ./file.geojson
+
+# multiple files
+tilesets upload-source <username> <id> file-1.geojson file-4.geojson
+
+# directory of files
+# Reading from a directory will not distinguish between GeoJSON files and non GeoJSON files. All source files will be run through our validator unless you pass the `--no-validation` flag.
+tilesets upload-source <username> <id> ./path/to/multiple/files/
+```
+
+### *deprecated* add-source
+
+*WARNING: add-source is maintained for legacy purposes. Please use the `upload-source` command instead.*
 
 ```shell
 tilesets add-source <username> <id> <file>

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -489,17 +489,22 @@ def validate_source(features):
     click.echo("✔ valid")
 
 
-@cli.command("add-source")
+@cli.command("upload-source")
 @click.argument("username", required=True, type=str)
 @click.argument("id", required=True, type=str)
 @cligj.features_in_arg
 @click.option("--no-validation", is_flag=True, help="Bypass source file validation")
 @click.option("--quiet", is_flag=True, help="Don't show progress bar")
+@click.option(
+    "--replace",
+    is_flag=True,
+    help="Replace the existing source with the new source file",
+)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 @click.option("--indent", type=int, default=None, help="Indent for JSON output")
 @click.pass_context
-def add_source(
-    ctx, username, id, features, no_validation, quiet, token=None, indent=None
+def upload_source(
+    ctx, username, id, features, no_validation, quiet, replace, token=None, indent=None
 ):
     """Create/add a tileset source
 
@@ -511,6 +516,10 @@ def add_source(
     url = (
         f"{mapbox_api}/tilesets/v1/sources/{username}/{id}?access_token={mapbox_token}"
     )
+
+    method = "post"
+    if replace:
+        method = "put"
 
     with tempfile.TemporaryFile() as file:
         for feature in features:
@@ -525,7 +534,7 @@ def add_source(
         m = MultipartEncoder(fields={"file": ("file", file)})
 
         if quiet:
-            resp = s.post(
+            resp = getattr(s, method)(
                 url,
                 data=m,
                 headers={
@@ -544,7 +553,7 @@ def add_source(
                     prog.update(0)  # Step is 0 because we set pos above
 
                 monitor = MultipartEncoderMonitor(m, callback)
-                resp = s.post(
+                resp = getattr(s, method)(
                     url,
                     data=monitor,
                     headers={
@@ -557,6 +566,35 @@ def add_source(
         click.echo(json.dumps(resp.json(), indent=indent))
     else:
         raise errors.TilesetsError(resp.text)
+
+
+@cli.command("add-source")
+@click.argument("username", required=True, type=str)
+@click.argument("id", required=True, type=str)
+@cligj.features_in_arg
+@click.option("--no-validation", is_flag=True, help="Bypass source file validation")
+@click.option("--quiet", is_flag=True, help="Don't show progress bar")
+@click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
+@click.option("--indent", type=int, default=None, help="Indent for JSON output")
+@click.pass_context
+def add_source(
+    ctx, username, id, features, no_validation, quiet, token=None, indent=None
+):
+    """Create/add/replace a tileset source
+
+    tilesets upload-source <username> <id> <path/to/source/data>
+    """
+    upload_source(
+        ctx,
+        username,
+        id,
+        features,
+        no_validation,
+        quiet,
+        False,
+        token,
+        indent,
+    )
 
 
 @cli.command("view-source")

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -507,15 +507,7 @@ def upload_source(
     ctx, username, id, features, no_validation, quiet, replace, token=None, indent=None
 ):
     return _upload_source(
-        ctx,
-        username,
-        id,
-        features,
-        no_validation,
-        quiet,
-        replace,
-        token,
-        indent
+        ctx, username, id, features, no_validation, quiet, replace, token, indent
     )
 
 
@@ -601,15 +593,7 @@ def add_source(
     tilesets add-source <username> <id> <path/to/source/data>
     """
     return _upload_source(
-        ctx,
-        username,
-        id,
-        features,
-        no_validation,
-        quiet,
-        False,
-        token,
-        indent
+        ctx, username, id, features, no_validation, quiet, False, token, indent
     )
 
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -506,6 +506,22 @@ def validate_source(features):
 def upload_source(
     ctx, username, id, features, no_validation, quiet, replace, token=None, indent=None
 ):
+    return _upload_source(
+        ctx,
+        username,
+        id,
+        features,
+        no_validation,
+        quiet,
+        replace,
+        token,
+        indent
+    )
+
+
+def _upload_source(
+    ctx, username, id, features, no_validation, quiet, replace, token=None, indent=None
+):
     """Create/add a tileset source
 
     tilesets add-source <username> <id> <path/to/source/data>
@@ -582,9 +598,9 @@ def add_source(
 ):
     """Create/add/replace a tileset source
 
-    tilesets upload-source <username> <id> <path/to/source/data>
+    tilesets add-source <username> <id> <path/to/source/data>
     """
-    upload_source(
+    return _upload_source(
         ctx,
         username,
         id,
@@ -593,7 +609,7 @@ def add_source(
         quiet,
         False,
         token,
-        indent,
+        indent
     )
 
 

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -128,6 +128,41 @@ def test_cli_upload_source_replace(
 
 
 @pytest.mark.usefixtures("token_environ")
+@mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoder")
+@mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoderMonitor")
+@mock.patch("requests.Session.put")
+def test_cli_upload_source_replace(
+    mock_request_post,
+    mock_multipart_encoder_monitor,
+    mock_multipart_encoder,
+    MockResponse,
+    MockMultipartEncoding,
+):
+    okay_response = {"id": "mapbox://tileset-source/test-user/hello-world"}
+    mock_request_post.return_value = MockResponse(okay_response, status_code=200)
+
+    expected_json = b'{"type":"Feature","geometry":{"type":"Point","coordinates":[125.6,10.1]},"properties":{"name":"Dinagat Islands"}}\n'
+
+    def side_effect(fields):
+        assert fields["file"][1].read() == expected_json
+        return MockMultipartEncoding()
+
+    mock_multipart_encoder.side_effect = side_effect
+
+    runner = CliRunner()
+    validated_result = runner.invoke(
+        upload_source,
+        ["test-user", "hello-world", "tests/fixtures/valid.ldgeojson", "--replace"],
+    )
+    assert validated_result.exit_code == 0
+
+    assert (
+        validated_result.output
+        == """{"id": "mapbox://tileset-source/test-user/hello-world"}\n"""
+    )
+
+
+@pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.Session.get")
 def test_cli_view_source(mock_request_get, MockResponse):
     message = {"id": "mapbox://tileset-source/test-user/hello-world"}

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -116,7 +116,8 @@ def test_cli_upload_source_replace(
 
     runner = CliRunner()
     validated_result = runner.invoke(
-        upload_source, ["test-user", "hello-world", "tests/fixtures/valid.ldgeojson", "--replace"]
+        upload_source,
+        ["test-user", "hello-world", "tests/fixtures/valid.ldgeojson", "--replace"],
     )
     assert validated_result.exit_code == 0
 

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -131,7 +131,7 @@ def test_cli_upload_source_replace(
 @mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoder")
 @mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoderMonitor")
 @mock.patch("requests.Session.put")
-def test_cli_upload_source_replace(
+def test_cli_upload_source_no_replace(
     mock_request_post,
     mock_multipart_encoder_monitor,
     mock_multipart_encoder,

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -7,6 +7,7 @@ import pytest
 
 from mapbox_tilesets.scripts.cli import (
     add_source,
+    upload_source,
     view_source,
     delete_source,
     validate_source,

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -92,6 +92,40 @@ def test_cli_add_source_no_validation(mock_request_post, MockResponse):
 
 
 @pytest.mark.usefixtures("token_environ")
+@mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoder")
+@mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoderMonitor")
+@mock.patch("requests.Session.put")
+def test_cli_upload_source_replace(
+    mock_request_put,
+    mock_multipart_encoder_monitor,
+    mock_multipart_encoder,
+    MockResponse,
+    MockMultipartEncoding,
+):
+    okay_response = {"id": "mapbox://tileset-source/test-user/hello-world"}
+    mock_request_put.return_value = MockResponse(okay_response, status_code=200)
+
+    expected_json = b'{"type":"Feature","geometry":{"type":"Point","coordinates":[125.6,10.1]},"properties":{"name":"Dinagat Islands"}}\n'
+
+    def side_effect(fields):
+        assert fields["file"][1].read() == expected_json
+        return MockMultipartEncoding()
+
+    mock_multipart_encoder.side_effect = side_effect
+
+    runner = CliRunner()
+    validated_result = runner.invoke(
+        upload_source, ["test-user", "hello-world", "tests/fixtures/valid.ldgeojson", "--replace"]
+    )
+    assert validated_result.exit_code == 0
+
+    assert (
+        validated_result.output
+        == """{"id": "mapbox://tileset-source/test-user/hello-world"}\n"""
+    )
+
+
+@pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.Session.get")
 def test_cli_view_source(mock_request_get, MockResponse):
     message = {"id": "mapbox://tileset-source/test-user/hello-world"}


### PR DESCRIPTION
Adds a new `upload-source` command that sends traffic to a tilesets PUT endpoint when the `--replace` flag is used. The `add-source` is an alias for the `upload-source` command, and future documentation will point users there.

## Next steps

- [x] Get tests working
- [x] Update documentation to recommend the `upload-source` command

cc/ @dianeschulze 