### PR TITLE
TravisCI releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,9 @@ after_script:
   - curl -S -f https://codecov.io/bash -o codecov
   - chmod +x codecov
   - ./codecov -Z
+deploy:
+  provider: pypi
+  user: mapboxci
+  distributions: "sdist bdist_wheel"
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ deploy:
   provider: pypi
   user: mapboxci
   distributions: "sdist bdist_wheel"
-  server: https://test.pypi.org
+  server: https://test.pypi.org/legacy/
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ deploy:
   provider: pypi
   user: mapboxci
   distributions: "sdist bdist_wheel"
+  server: https://test.pypi.org
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ after_script:
   - ./codecov -Z
 deploy:
   provider: pypi
-  user: "__token__"
+  user: "mapboxci"
   distributions: "sdist bdist_wheel"
-  server: https://test.pypi.org/legacy/
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ after_script:
   - ./codecov -Z
 deploy:
   provider: pypi
-  user: __token__
+  user: "__token__"
   distributions: "sdist bdist_wheel"
   server: https://test.pypi.org/legacy/
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ after_script:
   - ./codecov -Z
 deploy:
   provider: pypi
-  user: mapboxci
+  user: __token__
   distributions: "sdist bdist_wheel"
   server: https://test.pypi.org/legacy/
   on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 1.2.1-test-publish1 (2020-07-30)
+- test publishing `mapbox-tilesets` package on pypi with TravisCI
+
 # 1.2.1.dev0 (2020-07-24)
 - Send compact JSON during source upload
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 1.2.1 (2020-07-30)
+# 1.3.0 (2020-07-30)
 - Official PyPi release via TravisCI
 
 # 1.2.1.dev0 (2020-07-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
-# 0.0.1 (2020-07-30)
-- test publishing `mapbox-tilesets` package on pypi with TravisCI
+# 1.2.1 (2020-07-30)
+- Official PyPi release via TravisCI
 
 # 1.2.1.dev0 (2020-07-24)
 - Send compact JSON during source upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 1.2.1.test1 (2020-07-30)
+# 1.2.1t1 (2020-07-30)
 - test publishing `mapbox-tilesets` package on pypi with TravisCI
 
 # 1.2.1.dev0 (2020-07-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 1.2.1-test-publish2 (2020-07-30)
+# 1.2.1.test1 (2020-07-30)
 - test publishing `mapbox-tilesets` package on pypi with TravisCI
 
 # 1.2.1.dev0 (2020-07-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 1.0.0 (2020-07-30)
+# 0.0.1 (2020-07-30)
 - test publishing `mapbox-tilesets` package on pypi with TravisCI
 
 # 1.2.1.dev0 (2020-07-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 1.2.1t1 (2020-07-30)
+# 1.0.0 (2020-07-30)
 - test publishing `mapbox-tilesets` package on pypi with TravisCI
 
 # 1.2.1.dev0 (2020-07-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 1.2.1-test-publish1 (2020-07-30)
+# 1.2.1-test-publish2 (2020-07-30)
 - test publishing `mapbox-tilesets` package on pypi with TravisCI
 
 # 1.2.1.dev0 (2020-07-24)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,12 +54,13 @@ After which you can add these changes and commit again. Note that failing pre-co
 
 ## Release process
 
-Releases are simply tags on GitHub. Once changes have been merged to master:
+Releases to PyPi are handled via TravisCI and GitHub tags. Once changes have been merged to master:
 
 1. Update the version in tilesets/__init__.py
 2. Update the changelog
-3. Tag on github with `git tag`. For example `git tag -a v0.2.0 -m 'v0.2.0'`
-4. [Push new release to pypi](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives)
+3. Commit changes to GitHub. For example `git commit -am 'v0.2.0' && git push origin master`
+4. Tag on GitHub with `git tag`. For example `git tag -a v0.2.0 -m 'v0.2.0'`
+5. Look for the release at https://pypi.org/project/mapbox-tilesets/#history
 
 ## Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,12 @@ Releases to PyPi are handled via TravisCI and GitHub tags. Once changes have bee
 
 1. Update the version in tilesets/__init__.py
 2. Update the changelog
-3. Commit changes to GitHub. For example `git commit -am '0.2.0' && git push origin master`
-4. Tag on GitHub with `git tag`. For example `git tag -a v0.2.0 -m 'v0.2.0'`
-5. Watch for tag build on travis at https://travis-ci.com/github/mapbox/tilesets-cli/builds
-6. Once travis completes successfully, look for the release at https://pypi.org/project/mapbox-tilesets/#history
+3. Commit changes to **your branch**. For example `git commit -am '0.2.0' && git push origin HEAD`
+4. Get a review and merge your changes to master.
+5. Get the latest changes locally from master `git checkout master && git pull origin master`
+6. Tag on GitHub with `git tag` and push tags. For example `git tag -a v0.2.0 -m 'v0.2.0' && git push --tags`
+7. Watch for tag build on travis at https://travis-ci.com/github/mapbox/tilesets-cli/builds
+8. Once travis completes successfully, look for the release at https://pypi.org/project/mapbox-tilesets/#history
 
 ## Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,10 +62,6 @@ Releases to PyPi are handled via TravisCI and GitHub tags. Once changes have bee
 4. Tag on GitHub with `git tag`. For example `git tag -a v0.2.0 -m 'v0.2.0'`
 5. Look for the release at https://pypi.org/project/mapbox-tilesets/#history
 
-### pre-release
-
-Same as normal release process but include a dev tag in the `tilesets/__init__.py` version string. For example `0.2.0-dev0`. When you publish a git tag `v0.2.0-dev0` pypi will mark this as a "pre-release", which will only be installable when users include `--pre` in their pip installs.
-
 ## Tests
 
 All tests are runnable with pytest. pytest is not installed by default and can be installed with the pip test extras

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,10 @@ Releases to PyPi are handled via TravisCI and GitHub tags. Once changes have bee
 
 1. Update the version in tilesets/__init__.py
 2. Update the changelog
-3. Commit changes to GitHub. For example `git commit -am 'v0.2.0' && git push origin master`
+3. Commit changes to GitHub. For example `git commit -am '0.2.0' && git push origin master`
 4. Tag on GitHub with `git tag`. For example `git tag -a v0.2.0 -m 'v0.2.0'`
-5. Look for the release at https://pypi.org/project/mapbox-tilesets/#history
+5. Watch for tag build on travis at https://travis-ci.com/github/mapbox/tilesets-cli/builds
+6. Once travis completes successfully, look for the release at https://pypi.org/project/mapbox-tilesets/#history
 
 ## Tests
 

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.0.0"
+__version__ = "0.0.1"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.2.1t1"
+__version__ = "1.0.0"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.2.1-test-publish2"
+__version__ = "1.2.1.test1"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.2.1.dev0"
+__version__ = "1.2.1-test-publish1"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.2.1.test1"
+__version__ = "1.2.1t1"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.2.0.dev0"
+__version__ = "1.2.0"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.2.1-test-publish1"
+__version__ = "1.2.1-test-publish2"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "0.0.1"
+__version__ = "1.2.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[egg_info]
-tag_build = dev
-
-[upload]
-dry-run = 1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 
 setup(
-    name="mapsam-test-package",
+    name="mapbox-tilesets",
     version=__version__,
     description=u"CLI for interacting with and preparing data for the Tilesets API",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 
 setup(
-    name="mapbox-tilesets",
+    name="mapsam-test-package",
     version=__version__,
     description=u"CLI for interacting with and preparing data for the Tilesets API",
     long_description=long_description,


### PR DESCRIPTION
This updates our travis.yml file to release `mapbox-tilesets` to pypi on git tags. The release workflow is now the following (from CONTRIBUTING.md):

> Releases to PyPi are handled via TravisCI and GitHub tags. Once changes have been merged to master:
> 
> 1. Update the version in tilesets/__init__.py
> 2. Update the changelog
> 3. Commit changes to GitHub. For example `git commit -am '0.2.0' && git push origin master`
> 4. Tag on GitHub with `git tag`. For example `git tag -a v0.2.0 -m 'v0.2.0'`
> 5. Watch for tag build on travis at https://travis-ci.com/github/mapbox/tilesets-cli/builds
> 6. Once travis completes successfully, look for the release at https://pypi.org/project/mapbox-tilesets/#history

I bumped the version to 1.3.0 to have a clean official release, which won't be tagged as a pre-release on PyPi.org.

cc @Gerdie @jakepruitt for review!