### PR TITLE
pypi deploy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ after_script:
   - ./codecov -Z
 deploy:
   provider: pypi
-  user: "mapboxci"
+  user: __token__
+  password: $PYPI_PASSWORD
   distributions: "sdist bdist_wheel"
   on:
     tags: true


### PR DESCRIPTION
Fixes the travis file by setting `__token__` literal and using the token defined in the project settings.

cc @Gerdie 