### PR TITLE
Change status command to use /jobs endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 1.4.1 (2020-08-06)
+- Use the `/jobs` endpoint in the `status` command
+
 # 1.4.0 (2020-08-04)
 - Create upload-source command to replace add-source, with extra `--replace` option
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Flags:
 
 ### status
 
-View the status of a tileset. This includes how many jobs are queued, processing, and complete.
+View the status of a tileset. To get more detailed information about a tileset's jobs, including the timestamps of failed and successful jobs, use the `tielsets jobs <tileset_id>` command.
 
 ```
 tilesets status <tileset_id>

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Flags:
 
 ### status
 
-View the status of a tileset. To get more detailed information about a tileset's jobs, including the timestamps of failed and successful jobs, use the `tielsets jobs <tileset_id>` command.
+View the status of the most recent job for a tileset. To get more detailed information about a tileset's jobs, including the timestamps of failed and successful jobs, use the `tilesets jobs <tileset_id>` command.
 
 ```
 tilesets status <tileset_id>

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -232,12 +232,19 @@ def status(tileset, token=None, indent=None):
     mapbox_api = utils._get_api()
     mapbox_token = utils._get_token(token)
     s = utils._get_session()
-    url = "{0}/tilesets/v1/{1}/status?access_token={2}".format(
+    url = "{0}/tilesets/v1/{1}/jobs?limit=1&access_token={2}".format(
         mapbox_api, tileset, mapbox_token
     )
     r = s.get(url)
 
-    click.echo(json.dumps(r.json(), indent=indent))
+    status = {}
+    for job in r.json():
+        status["id"] = job["tilesetId"]
+        status["latest_job"] = job["id"]
+        status["status"] = job["stage"]
+        status["last_modified"] = job["created_nice"]
+
+    click.echo(json.dumps(status, indent=indent))
 
 
 @cli.command("tilejson")

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -242,7 +242,6 @@ def status(tileset, token=None, indent=None):
         status["id"] = job["tilesetId"]
         status["latest_job"] = job["id"]
         status["status"] = job["stage"]
-        status["last_modified"] = job["created_nice"]
 
     click.echo(json.dumps(status, indent=indent))
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -13,27 +13,29 @@ def test_cli_status(mock_request_get, MockResponse):
     runner = CliRunner()
 
     # sends expected request
-    message = {"message": "mock message"}
+    message = [{"id": "a123", "created_nice": "Tuesday, August 04, 2020", "stage": "processing", "tilesetId": "test.id"}]
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(status, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/status?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?limit=1&access_token=fake-token"
     )
     assert result.exit_code == 0
-    assert json.loads(result.output) == message
+    expected_status = {"id": "test.id", "last_modified": "Tuesday, August 04, 2020", "status": "processing", "latest_job": "a123"}
+    assert json.loads(result.output) == expected_status
 
 
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.Session.get")
 def test_cli_status_use_token_flag(mock_request_get, MockResponse):
     runner = CliRunner()
-    message = {"message": "mock message"}
+    message = [{"id": "a123", "created_nice": "Tuesday, August 04, 2020", "stage": "processing", "tilesetId": "test.id"}]
     mock_request_get.return_value = MockResponse(message)
     # Provides the flag --token
     result = runner.invoke(status, ["test.id", "--token", "flag-token"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/status?access_token=flag-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?limit=1&access_token=flag-token"
     )
 
     assert result.exit_code == 0
-    assert json.loads(result.output) == {"message": "mock message"}
+    expected_status = {"id": "test.id", "last_modified": "Tuesday, August 04, 2020", "status": "processing", "latest_job": "a123"}
+    assert json.loads(result.output) == expected_status

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -13,14 +13,26 @@ def test_cli_status(mock_request_get, MockResponse):
     runner = CliRunner()
 
     # sends expected request
-    message = [{"id": "a123", "created_nice": "Tuesday, August 04, 2020", "stage": "processing", "tilesetId": "test.id"}]
+    message = [
+        {
+            "id": "a123",
+            "created_nice": "Tuesday, August 04, 2020",
+            "stage": "processing",
+            "tilesetId": "test.id",
+        }
+    ]
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(status, ["test.id"])
     mock_request_get.assert_called_with(
         "https://api.mapbox.com/tilesets/v1/test.id/jobs?limit=1&access_token=fake-token"
     )
     assert result.exit_code == 0
-    expected_status = {"id": "test.id", "last_modified": "Tuesday, August 04, 2020", "status": "processing", "latest_job": "a123"}
+    expected_status = {
+        "id": "test.id",
+        "last_modified": "Tuesday, August 04, 2020",
+        "status": "processing",
+        "latest_job": "a123",
+    }
     assert json.loads(result.output) == expected_status
 
 
@@ -28,7 +40,14 @@ def test_cli_status(mock_request_get, MockResponse):
 @mock.patch("requests.Session.get")
 def test_cli_status_use_token_flag(mock_request_get, MockResponse):
     runner = CliRunner()
-    message = [{"id": "a123", "created_nice": "Tuesday, August 04, 2020", "stage": "processing", "tilesetId": "test.id"}]
+    message = [
+        {
+            "id": "a123",
+            "created_nice": "Tuesday, August 04, 2020",
+            "stage": "processing",
+            "tilesetId": "test.id",
+        }
+    ]
     mock_request_get.return_value = MockResponse(message)
     # Provides the flag --token
     result = runner.invoke(status, ["test.id", "--token", "flag-token"])
@@ -37,5 +56,10 @@ def test_cli_status_use_token_flag(mock_request_get, MockResponse):
     )
 
     assert result.exit_code == 0
-    expected_status = {"id": "test.id", "last_modified": "Tuesday, August 04, 2020", "status": "processing", "latest_job": "a123"}
+    expected_status = {
+        "id": "test.id",
+        "last_modified": "Tuesday, August 04, 2020",
+        "status": "processing",
+        "latest_job": "a123",
+    }
     assert json.loads(result.output) == expected_status

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -13,13 +13,7 @@ def test_cli_status(mock_request_get, MockResponse):
     runner = CliRunner()
 
     # sends expected request
-    message = [
-        {
-            "id": "a123",
-            "stage": "processing",
-            "tilesetId": "test.id",
-        }
-    ]
+    message = [{"id": "a123", "stage": "processing", "tilesetId": "test.id",}]
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(status, ["test.id"])
     mock_request_get.assert_called_with(
@@ -38,13 +32,7 @@ def test_cli_status(mock_request_get, MockResponse):
 @mock.patch("requests.Session.get")
 def test_cli_status_use_token_flag(mock_request_get, MockResponse):
     runner = CliRunner()
-    message = [
-        {
-            "id": "a123",
-            "stage": "processing",
-            "tilesetId": "test.id",
-        }
-    ]
+    message = [{"id": "a123", "stage": "processing", "tilesetId": "test.id",}]
     mock_request_get.return_value = MockResponse(message)
     # Provides the flag --token
     result = runner.invoke(status, ["test.id", "--token", "flag-token"])

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -13,7 +13,7 @@ def test_cli_status(mock_request_get, MockResponse):
     runner = CliRunner()
 
     # sends expected request
-    message = [{"id": "a123", "stage": "processing", "tilesetId": "test.id",}]
+    message = [{"id": "a123", "stage": "processing", "tilesetId": "test.id"}]
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(status, ["test.id"])
     mock_request_get.assert_called_with(
@@ -32,7 +32,7 @@ def test_cli_status(mock_request_get, MockResponse):
 @mock.patch("requests.Session.get")
 def test_cli_status_use_token_flag(mock_request_get, MockResponse):
     runner = CliRunner()
-    message = [{"id": "a123", "stage": "processing", "tilesetId": "test.id",}]
+    message = [{"id": "a123", "stage": "processing", "tilesetId": "test.id"}]
     mock_request_get.return_value = MockResponse(message)
     # Provides the flag --token
     result = runner.invoke(status, ["test.id", "--token", "flag-token"])

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -16,7 +16,6 @@ def test_cli_status(mock_request_get, MockResponse):
     message = [
         {
             "id": "a123",
-            "created_nice": "Tuesday, August 04, 2020",
             "stage": "processing",
             "tilesetId": "test.id",
         }
@@ -29,7 +28,6 @@ def test_cli_status(mock_request_get, MockResponse):
     assert result.exit_code == 0
     expected_status = {
         "id": "test.id",
-        "last_modified": "Tuesday, August 04, 2020",
         "status": "processing",
         "latest_job": "a123",
     }
@@ -43,7 +41,6 @@ def test_cli_status_use_token_flag(mock_request_get, MockResponse):
     message = [
         {
             "id": "a123",
-            "created_nice": "Tuesday, August 04, 2020",
             "stage": "processing",
             "tilesetId": "test.id",
         }
@@ -58,7 +55,6 @@ def test_cli_status_use_token_flag(mock_request_get, MockResponse):
     assert result.exit_code == 0
     expected_status = {
         "id": "test.id",
-        "last_modified": "Tuesday, August 04, 2020",
         "status": "processing",
         "latest_job": "a123",
     }


### PR DESCRIPTION
Closes #89 and #81 

Uses the `/jobs` endpoint for the `status` command to maintain backwards compatibility for the CLI while reducing the usage of the `/status` endpoint.

Also adds a `last_modified` field in the status.

cc/ @dianeschulze 