### PR TITLE
Report an error quickly if the token username doesn't match the username

### DIFF
--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -4,6 +4,7 @@ import tempfile
 
 import click
 import cligj
+import base64
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
 import mapbox_tilesets
@@ -528,6 +529,14 @@ def _upload_source(
     method = "post"
     if replace:
         method = "put"
+
+    token_parts = mapbox_token.split('.')
+    if len(token_parts) > 1:
+        while len(token_parts[1]) % 4 != 0:
+            token_parts[1] = token_parts[1] + '='
+        body = json.loads(base64.b64decode(token_parts[1]))
+        if 'u' in body and username != body['u']:
+            raise errors.TilesetsError(f"Token username {body['u']} does not match username {username}")
 
     with tempfile.TemporaryFile() as file:
         for feature in features:

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -530,13 +530,15 @@ def _upload_source(
     if replace:
         method = "put"
 
-    token_parts = mapbox_token.split('.')
+    token_parts = mapbox_token.split(".")
     if len(token_parts) > 1:
         while len(token_parts[1]) % 4 != 0:
-            token_parts[1] = token_parts[1] + '='
+            token_parts[1] = token_parts[1] + "="
         body = json.loads(base64.b64decode(token_parts[1]))
-        if 'u' in body and username != body['u']:
-            raise errors.TilesetsError(f"Token username {body['u']} does not match username {username}")
+        if "u" in body and username != body["u"]:
+            raise errors.TilesetsError(
+                f"Token username {body['u']} does not match username {username}"
+            )
 
     with tempfile.TemporaryFile() as file:
         for feature in features:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ from json.decoder import JSONDecodeError
 
 @pytest.fixture(scope="function")
 def token_environ(monkeypatch):
-    monkeypatch.setenv("MAPBOX_ACCESS_TOKEN", "fake-token")
+    # '{"u":"test-user"}' in base64
+    monkeypatch.setenv("MAPBOX_ACCESS_TOKEN", "pk.eyJ1IjoidGVzdC11c2VyIn0K")
     monkeypatch.setenv("MapboxAccessToken", "test-token")
 
 

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -50,7 +50,7 @@ def test_cli_create_success(mock_request_post, MockResponse):
     )
     assert result.exit_code == 0
     mock_request_post.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token",
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
         json={
             "name": "test name",
             "description": "",
@@ -108,7 +108,7 @@ def test_cli_create_success_description(mock_request_post, MockResponse):
     assert result.exit_code == 0
 
     mock_request_post.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token",
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
         json={
             "name": "test name",
             "description": "test description",

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -28,7 +28,7 @@ def test_cli_delete(mock_request_delete):
     mock_request_delete.return_value = MockResponse("", status_code=200)
     result = runner.invoke(delete, ["test.id"], input="test.id")
     mock_request_delete.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 0
     assert (
@@ -62,7 +62,7 @@ def test_cli_delete_force(mock_request_delete):
     mock_request_delete.return_value = MockResponse("", status_code=204)
     result = runner.invoke(delete, ["test.id", "--force"])
     mock_request_delete.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 0
     assert result.output == "Tileset deleted.\n"
@@ -79,7 +79,7 @@ def test_cli_delete_fail(mock_request_delete):
     )
     result = runner.invoke(delete, ["test.id", "--force"])
     mock_request_delete.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 1
     assert isinstance(result.exception, TilesetsError)

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -17,7 +17,7 @@ def test_cli_job(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(jobs, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=100"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message
@@ -34,7 +34,7 @@ def test_cli_job_error(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message, status_code=404)
     result = runner.invoke(jobs, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=100"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message
@@ -51,7 +51,7 @@ def test_cli_jobs_and_stage(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(jobs, ["test.id", "--stage", "success"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=100&stage=success"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&stage=success"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message
@@ -68,7 +68,7 @@ def test_cli_jobs_limit(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(jobs, ["test.id", "--limit", "10"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=10"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=10"
     )
     assert result.exit_code == 0
 
@@ -93,7 +93,7 @@ def test_cli_jobs_stage_and_limit(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(jobs, ["test.id", "--stage", "success", "--limit", "10"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=fake-token&limit=10&stage=success"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=10&stage=success"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message
@@ -110,7 +110,7 @@ def test_cli_single_job(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(job, ["test.id", "job_id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/jobs/job_id?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/jobs/job_id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -21,7 +21,7 @@ def test_cli_list(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -40,7 +40,7 @@ def test_cli_list_verbose(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--verbose"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100"
     )
     assert result.exit_code == 0
 
@@ -59,7 +59,7 @@ def test_cli_list_bad_token(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message, status_code=404)
     result = runner.invoke(list, ["test"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100"
     )
     assert result.exit_code == 1
     assert result.exception
@@ -78,7 +78,7 @@ def test_cli_list_type_vector(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--type", "vector"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&type=vector"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&type=vector"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -97,7 +97,7 @@ def test_cli_list_type_raster(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--type", "raster"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&type=raster"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&type=raster"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -116,7 +116,7 @@ def test_cli_list_visibility_public(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--visibility", "public"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&visibility=public"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&visibility=public"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -135,7 +135,7 @@ def test_cli_list_visibility_private(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--visibility", "private"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&visibility=private"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&visibility=private"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -154,7 +154,7 @@ def test_cli_list_sortby_created(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--sortby", "created"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&sortby=created"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&sortby=created"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -173,7 +173,7 @@ def test_cli_list_sortby_modified(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--sortby", "modified"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=100&sortby=modified"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&sortby=modified"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -192,7 +192,7 @@ def test_cli_list_limit_10(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(list, ["test", "--limit", "10"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=10"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=10"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""
@@ -233,7 +233,7 @@ def test_cli_list_options(mock_request_get, MockResponse):
         ],
     )
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=fake-token&limit=10&type=vector&visibility=private&sortby=created"
+        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=10&type=vector&visibility=private&sortby=created"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""

--- a/tests/test_cli_publish.py
+++ b/tests/test_cli_publish.py
@@ -29,7 +29,7 @@ def test_cli_publish(mock_request_post):
     mock_request_post.return_value = MockResponse({"message": "mock message"}, 200)
     result = runner.invoke(publish, ["test.id"])
     mock_request_post.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/publish?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/publish?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 0
     assert (

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -62,21 +62,8 @@ def test_cli_add_source_wrong_username(
 ):
     if "MAPBOX_ACCESS_TOKEN" in os.environ:
         del os.environ["MAPBOX_ACCESS_TOKEN"]
-    if "MapboxAccessToken" in os.environ:
-        del os.environ["MapboxAccessToken"]
 
     os.environ["MapboxAccessToken"] = "pk.eyJ1Ijoid3JvbmctdXNlciJ9Cg.xxx"
-
-    okay_response = {"id": "mapbox://tileset-source/test-user/hello-world"}
-    mock_request_post.return_value = MockResponse(okay_response, status_code=200)
-
-    expected_json = b'{"type":"Feature","geometry":{"type":"Point","coordinates":[125.6,10.1]},"properties":{"name":"Dinagat Islands"}}\n'
-
-    def side_effect(fields):
-        assert fields["file"][1].read() == expected_json
-        return MockMultipartEncoding()
-
-    mock_multipart_encoder.side_effect = side_effect
 
     runner = CliRunner()
     validated_result = runner.invoke(

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -63,6 +63,7 @@ def test_cli_add_source_wrong_username(
     if "MAPBOX_ACCESS_TOKEN" in os.environ:
         del os.environ["MAPBOX_ACCESS_TOKEN"]
 
+    # This is the base64 encoding of '{"u":"wrong-user"}', not a real token
     os.environ["MapboxAccessToken"] = "pk.eyJ1Ijoid3JvbmctdXNlciJ9Cg.xxx"
 
     runner = CliRunner()

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -17,7 +17,7 @@ def test_cli_status(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(status, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/status?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/status?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message

--- a/tests/test_cli_tilejson.py
+++ b/tests/test_cli_tilejson.py
@@ -49,7 +49,7 @@ def test_cli_tilejson(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(tilejson, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/v4/test.id.json?access_token=fake-token"
+        "https://api.mapbox.com/v4/test.id.json?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 0
 
@@ -63,7 +63,7 @@ def test_cli_tilejson_composite(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse("")
     result = runner.invoke(tilejson, ["test.id,test.another"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/v4/test.id,test.another.json?access_token=fake-token"
+        "https://api.mapbox.com/v4/test.id,test.another.json?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 0
 
@@ -77,7 +77,7 @@ def test_cli_tilejson_secure(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse("")
     result = runner.invoke(tilejson, ["test.id", "--secure"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/v4/test.id.json?access_token=fake-token&secure"
+        "https://api.mapbox.com/v4/test.id.json?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&secure"
     )
     assert result.exit_code == 0
 
@@ -91,7 +91,7 @@ def test_cli_tilejson_error(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse({"message": "uh oh"}, 422)
     result = runner.invoke(tilejson, ["test.id,test.another"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/v4/test.id,test.another.json?access_token=fake-token"
+        "https://api.mapbox.com/v4/test.id,test.another.json?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 1
     assert isinstance(result.exception, TilesetsError)

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -39,7 +39,7 @@ def test_cli_patch(mock_request_patch):
     )
 
     mock_request_patch.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token",
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
         json={
             "name": "hola",
             "description": "hello world",
@@ -63,7 +63,7 @@ def test_cli_patch_no_options(mock_request_patch):
     result = runner.invoke(update, ["test.id"])
 
     mock_request_patch.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id?access_token=fake-token", json={}
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K", json={}
     )
     assert result.exit_code == 0
     assert result.output == ""

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -63,7 +63,8 @@ def test_cli_patch_no_options(mock_request_patch):
     result = runner.invoke(update, ["test.id"])
 
     mock_request_patch.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K", json={}
+        "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
+        json={},
     )
     assert result.exit_code == 0
     assert result.output == ""

--- a/tests/test_cli_update_recipe.py
+++ b/tests/test_cli_update_recipe.py
@@ -24,7 +24,7 @@ def test_cli_update_recipe_201(mock_request_patch, MockResponse):
     mock_request_patch.return_value = MockResponse({}, status_code=201)
     result = runner.invoke(update_recipe, ["test.id", "tests/fixtures/recipe.json"])
     mock_request_patch.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=fake-token",
+        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
         json={"minzoom": 0, "maxzoom": 10, "layer_name": "test_layer"},
     )
     assert result.exit_code == 0
@@ -39,7 +39,7 @@ def test_cli_update_recipe_204(mock_request_patch, MockResponse):
     mock_request_patch.return_value = MockResponse("", status_code=204)
     result = runner.invoke(update_recipe, ["test.id", "tests/fixtures/recipe.json"])
     mock_request_patch.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=fake-token",
+        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
         json={"minzoom": 0, "maxzoom": 10, "layer_name": "test_layer"},
     )
     assert result.exit_code == 0

--- a/tests/test_cli_validate_recipe.py
+++ b/tests/test_cli_validate_recipe.py
@@ -34,7 +34,7 @@ def test_cli_validate_recipe(mock_request_put, MockResponse):
     mock_request_put.return_value = MockResponse(message)
     result = runner.invoke(validate_recipe, ["tests/fixtures/recipe.json"])
     mock_request_put.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/validateRecipe?access_token=fake-token",
+        "https://api.mapbox.com/tilesets/v1/validateRecipe?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
         json={"minzoom": 0, "maxzoom": 10, "layer_name": "test_layer"},
     )
     assert result.exit_code == 0

--- a/tests/test_cli_view_recipe.py
+++ b/tests/test_cli_view_recipe.py
@@ -17,7 +17,7 @@ def test_cli_view_recipe(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse(message)
     result = runner.invoke(view_recipe, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 0
     assert json.loads(result.output) == message
@@ -47,7 +47,7 @@ def test_cli_view_recipe_raises(mock_request_get, MockResponse):
     mock_request_get.return_value = MockResponse("not found", status_code=404)
     result = runner.invoke(view_recipe, ["test.id"])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=fake-token"
+        "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 1
 


### PR DESCRIPTION
This avoids the broken pipe reported in https://github.com/mapbox/tilesets-cli/issues/76 when the server reports the error and closes the connection before the client has finished sending the `add-source` data.