### PR TITLE
Click upgrade to 7.1.2

### DIFF
--- a/mapbox_tilesets/errors.py
+++ b/mapbox_tilesets/errors.py
@@ -20,8 +20,7 @@ class TilesetsError(Exception):
 
 
 class TilesetNameError(TilesetsError):
-    """Not a valid tileset id
-    """
+    """Not a valid tileset id"""
 
     def __init__(self, tileset_id):
         self.tileset_id = tileset_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.9.99
-Click==7.0
+Click==7.1.2
 cligj==0.5.0
 requests==2.21.0
 requests-toolbelt==0.9.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
     install_requires=[
         "boto3",
-        "click~=7.2.1",
+        "click~=7.1.2",
         "cligj",
         "requests",
         "requests-toolbelt",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
     install_requires=[
         "boto3",
-        "click~=7.0",
+        "click~=7.2.1",
         "cligj",
         "requests",
         "requests-toolbelt",

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -14,7 +14,7 @@ def test_cli_create_missing_recipe():
     # missing --recipe option
     result = runner.invoke(create, ["test.id"])
     assert result.exit_code == 2
-    assert "Error: Missing option '--recipe' / '-r'" in result.output
+    assert "Missing option '--recipe' / '-r'" in result.output
 
 
 @pytest.mark.usefixtures("token_environ")

--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -14,7 +14,7 @@ def test_cli_create_missing_recipe():
     # missing --recipe option
     result = runner.invoke(create, ["test.id"])
     assert result.exit_code == 2
-    assert 'Missing option "--recipe"' in result.output
+    assert "Error: Missing option '--recipe' / '-r'" in result.output
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -25,7 +25,7 @@ def test_cli_create_missing_name():
         create, ["test.id", "--recipe", "tests/fixtures/recipe.json"]
     )
     assert result.exit_code == 2
-    assert 'Missing option "--name"' in result.output
+    assert "Missing option '--name'" in result.output
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -140,7 +140,7 @@ def test_cli_create_private_invalid(mock_request_post, MockResponse):
     )
     assert result.exit_code == 2
     assert (
-        'Invalid value for "--privacy" / "-p": invalid choice: invalid-privacy-value. (choose from public, private)'
+        "Invalid value for '--privacy' / '-p': invalid choice: invalid-privacy-value. (choose from public, private)"
         in result.output
     )
 

--- a/tests/test_cli_update_recipe.py
+++ b/tests/test_cli_update_recipe.py
@@ -12,7 +12,7 @@ def test_cli_update_recipe_no_recipe():
     runner = CliRunner()
     result = runner.invoke(update_recipe, ["test.id", "does/not/exist/recipe.json"])
     assert result.exit_code == 2
-    assert 'Path "does/not/exist/recipe.json" does not exist' in result.output
+    assert "Path 'does/not/exist/recipe.json' does not exist" in result.output
 
 
 @pytest.mark.usefixtures("token_environ")

--- a/tests/test_cli_validate_recipe.py
+++ b/tests/test_cli_validate_recipe.py
@@ -21,7 +21,7 @@ def test_cli_validate_recipe_no_recipe():
     runner = CliRunner()
     result = runner.invoke(validate_recipe, ["does/not/exist/recipe.json"])
     assert result.exit_code == 2
-    assert 'Path "does/not/exist/recipe.json" does not exist' in result.output
+    assert "Path 'does/not/exist/recipe.json' does not exist" in result.output
 
 
 @pytest.mark.usefixtures("token_environ")


### PR DESCRIPTION
Upgrades the Click version from 7.0 to [7.1.2](https://click.palletsprojects.com/en/7.x/changelog/?highlight=version#version-7-1-2) which is the version when a [user pip installs click](https://pypi.org/project/click/). Click version 7.0 had quote formatting that failed with version 7.1.2 assertion tests. 

If you pull the master branch locally you will fail 5/70 tests if you have click 7.1.2 due to the version incompatibility so this change is necessary to safeguard against test inconsistency and be up to the date with new user's installations.

Example assertion test that failed 
![Screen Shot 2020-10-06 at 3 14 55 PM](https://user-images.githubusercontent.com/12984571/95265769-bf66f400-07e6-11eb-883f-dded3c9f5ca9.png)

Master before update 
![Screen Shot 2020-10-07 at 10 51 27 AM](https://user-images.githubusercontent.com/12984571/95368494-11615580-088b-11eb-80db-2825d3d7cf70.png)


Master after update 
![Screen Shot 2020-10-07 at 10 49 09 AM](https://user-images.githubusercontent.com/12984571/95368313-d2cb9b00-088a-11eb-88de-31c024b1c214.png)

