### PR TITLE
Release version 1.4.3 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 1.4.3 (2020-10-08)
+- Update Click version to 7.1.2 and fix assertions to pass all tests 
+
 # 1.4.2 (2020-08-18)
 - Check if the token matches the username before uploading sources
 

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"


### PR DESCRIPTION
With the changes from PR #102 to upgrade Click to version 7.1.2 and fixes assertion test that were failing due to quotes. 