### PR TITLE
Delete package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
This is a Python package and there isn't an associated `package.json` document.