### PR TITLE
update command descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
-- Provide description for `upload-source` command, and label `add-source` command as deprecated.
 
 =======
+
+# 1.7.2 (2021-10-01)
+- Provide description for `upload-source` command, and label `add-source` command as deprecated.
 
 # 1.7.1 (2021-04-16)
 - Switch to codecov python module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Provide description for `upload-source` command, and label `add-source` command as deprecated.
 
 =======
 

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -524,6 +524,11 @@ def validate_source(features):
 def upload_source(
     ctx, username, id, features, no_validation, quiet, replace, token=None, indent=None
 ):
+    """Create a new tileset source, or add data to an existing tileset source.
+    Optionally, replace an existing tileset source.
+
+    tilesets upload-source <username> <source_id> <path/to/source/data>
+    """
     return _upload_source(
         ctx, username, id, features, no_validation, quiet, replace, token, indent
     )
@@ -532,10 +537,6 @@ def upload_source(
 def _upload_source(
     ctx, username, id, features, no_validation, quiet, replace, token=None, indent=None
 ):
-    """Create/add a tileset source
-
-    tilesets add-source <username> <source_id> <path/to/source/data>
-    """
     mapbox_api = utils._get_api()
     mapbox_token = utils._get_token(token)
     s = utils._get_session()
@@ -627,7 +628,7 @@ def _upload_source(
 def add_source(
     ctx, username, id, features, no_validation, quiet, token=None, indent=None
 ):
-    """Create/add/replace a tileset source
+    """[DEPRECATED] Create/add/replace a tileset source. Use upload-source instead.
 
     tilesets add-source <username> <source_id> <path/to/source/data>
     """


### PR DESCRIPTION
- Provide description for `upload-source` command
- Label `add-source` command as deprecated.

```
tilesets --help
Usage: tilesets [OPTIONS] COMMAND [ARGS]...

  This is the command line interface for the Mapbox Tilesets API. Thanks for
  joining us.

  This CLI requires a Mapbox access token. You can either set it in your
  environment as "MAPBOX_ACCESS_TOKEN" or "MapboxAccessToken" or pass it to
  each command with the --token flag.

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  add-source       [DEPRECATED] Create/add/replace a tileset source.
  create           Create a new tileset with a recipe.
  delete           Delete your tileset.
  delete-source    Delete a Tileset Source + all of its files.
  estimate-area    Estimate area of features with a precision level.
  job              View a single job for a particular tileset.
  jobs             View all jobs for a particular tileset.
  list             List all tilesets for an account.
  list-sources     List all Tileset Sources for an account.
  publish          Publish your tileset.
  status           View the current queue/processing/complete status of
                   your...

  tilejson         View the TileJSON of a particular tileset.
  update           Update a tileset's information.
  update-recipe    Update a Recipe JSON document for a particular tileset...
  upload-source    Create a new tileset source, or add data to an existing...
  validate-recipe  Validate a Recipe JSON document tilesets validate-recipe...
  validate-source  Validate your source file.
  view-recipe      View a tileset's recipe JSON tilesets view-recipe...
  view-source      View a Tileset Source's information tilesets view-source...
```