### PR TITLE
tag tilesets api team rather than individuals in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Welcome
 
-Hi there! Welcome to the tilesets-cli contributing document. Issues, comments, and pull requests are welcome. Please tag @mapsam, @dianeschulze, and @dnomadb for any questions or reviews.
+Hi there! Welcome to the tilesets-cli contributing document. Issues, comments, and pull requests are welcome. Please tag @mapbox/tilesets-api for any questions or reviews.
 
 ## Installation
 First, clone the repo and `cd` into the folder:


### PR DESCRIPTION
tag tilesets api team rather than individuals in contributing docs