### PR TITLE
deprecate add-source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.7.3 (unreleased)
+- Mark `add-source` command as deprecated and hide from `--help` output.
+
 # 1.7.2 (2021-10-01)
 - Provide description for `upload-source` command, and label `add-source` command as deprecated.
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -616,7 +616,7 @@ def _upload_source(
         raise errors.TilesetsError(resp.text)
 
 
-@cli.command("add-source")
+@cli.command("add-source", deprecated=True, hidden=True)
 @click.argument("username", required=True, type=str)
 @click.argument("id", required=True, type=str)
 @cligj.features_in_arg
@@ -628,7 +628,9 @@ def _upload_source(
 def add_source(
     ctx, username, id, features, no_validation, quiet, token=None, indent=None
 ):
-    """[DEPRECATED] Create/add/replace a tileset source. Use upload-source instead.
+    """Use upload-source instead.
+
+    Create/add/replace a tileset source.
 
     tilesets add-source <username> <source_id> <path/to/source/data>
     """


### PR DESCRIPTION
Resolves #142 by hiding the `add-source` command from the help output, unless specifically requested.


`tilesets add-source --help`
![Screen Shot 2021-10-26 at 12 25 06 PM](https://user-images.githubusercontent.com/1943001/138947753-91d2bbd0-5f5f-49e3-aaa1-58b3bc9f0747.png)


`tilesets --help`
![Screen Shot 2021-10-26 at 12 24 34 PM](https://user-images.githubusercontent.com/1943001/138947755-2d3f306c-fb27-49ff-ab32-53dace5f5184.png)

cc @mapbox/tilesets-api 
