### PR TITLE
hide deprecated command from help list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Hide deprecated `add-source` command from command list.
 
 =======
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -616,7 +616,7 @@ def _upload_source(
         raise errors.TilesetsError(resp.text)
 
 
-@cli.command("add-source")
+@cli.command("add-source", hidden=True)
 @click.argument("username", required=True, type=str)
 @click.argument("id", required=True, type=str)
 @cligj.features_in_arg


### PR DESCRIPTION
Doc: https://click.palletsprojects.com/en/8.0.x/api/#click.Command

New help output:
```
tilesets --help
Usage: tilesets [OPTIONS] COMMAND [ARGS]...

  This is the command line interface for the Mapbox Tilesets API. Thanks for
  joining us.

  This CLI requires a Mapbox access token. You can either set it in your
  environment as "MAPBOX_ACCESS_TOKEN" or "MapboxAccessToken" or pass it to
  each command with the --token flag.

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  create           Create a new tileset with a recipe.
  delete           Delete your tileset.
  delete-source    Delete a Tileset Source + all of its files.
  estimate-area    Estimate area of features with a precision level.
  job              View a single job for a particular tileset.
  jobs             View all jobs for a particular tileset.
  list             List all tilesets for an account.
  list-sources     List all Tileset Sources for an account.
  publish          Publish your tileset.
  status           View the current queue/processing/complete status of
                   your...

  tilejson         View the TileJSON of a particular tileset.
  update           Update a tileset's information.
  update-recipe    Update a Recipe JSON document for a particular tileset...
  upload-source    Create a new tileset source, or add data to an existing...
  validate-recipe  Validate a Recipe JSON document tilesets validate-recipe...
  validate-source  Validate your source file.
  view-recipe      View a tileset's recipe JSON tilesets view-recipe...
  view-source      View a Tileset Source's information tilesets view-source...
```