### PR TITLE
raise errors for non 200s in status resp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Hide deprecated `add-source` command from command list.
+- Raise error in `tilesets status` for non-200s (includes unpublished tilesets).
 
 =======
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -249,6 +249,9 @@ def status(tileset, token=None, indent=None):
     )
     r = s.get(url)
 
+    if r.status_code != 200:
+        raise errors.TilesetsError(r.text)
+
     status = {}
     for job in r.json():
         status["id"] = job["tilesetId"]


### PR DESCRIPTION
re: https://github.com/mapbox/tilesets-cli/issues/127

new behavior:

```
tilesets status mariamoy.unpublished
Traceback (most recent call last):
  File "/Users/mariamoy/tilesets-cli/.env3/bin/tilesets", line 11, in <module>
    load_entry_point('mapbox-tilesets', 'console_scripts', 'tilesets')()
  File "/Users/mariamoy/tilesets-cli/.env3/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mariamoy/tilesets-cli/.env3/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/mariamoy/tilesets-cli/.env3/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/mariamoy/tilesets-cli/.env3/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/mariamoy/tilesets-cli/.env3/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/mariamoy/tilesets-cli/mapbox_tilesets/scripts/cli.py", line 253, in status
    raise errors.TilesetsError(r.text)
mapbox_tilesets.errors.TilesetsError: {"message":"mariamoy.unpublished has no jobs."}
```