### PR TITLE
Make `estimate-area` and rasterio/GDAL optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - '3.6'
+  - '3.7'
 install:
   - pip install -r requirements.txt -e .[test]
 script:
@@ -16,4 +17,5 @@ deploy:
   password: $PYPI_PASSWORD
   distributions: "sdist bdist_wheel"
   on:
+    python: 3.7
     tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 =======
 
+# 1.7.3
+ - Loads `supermercado` on request because binaries for arm64 MacOS and Windows are not easily available.
+
 # 1.7.2 (2021-10-01)
 - Provide description for `upload-source` command, and label `add-source` command as deprecated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Unreleased
-- Hide deprecated `add-source` command from command list.
-- Raise error in `tilesets status` for non-200s (includes unpublished tilesets).
 
 =======
 
-# 1.7.3
+# 1.7.3a1
  - Loads `supermercado` on request because binaries for arm64 MacOS and Windows are not easily available.
+ - Hide deprecated `add-source` command from command list.
+ - Raise error in `tilesets status` for non-200s (includes unpublished tilesets).
 
 # 1.7.2 (2021-10-01)
 - Provide description for `upload-source` command, and label `add-source` command as deprecated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 =======
 
-# 1.7.3a1
+# 1.7.3
  - Loads `supermercado` on request because binaries for arm64 MacOS and Windows are not easily available.
  - Hide deprecated `add-source` command from command list.
  - Raise error in `tilesets status` for non-200s (includes unpublished tilesets).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 =======
 
-# 1.7.3
+# 1.7.3 (2022-03-14)
  - Loads `supermercado` on request because binaries for arm64 MacOS and Windows are not easily available.
  - Hide deprecated `add-source` command from command list.
  - Raise error in `tilesets status` for non-200s (includes unpublished tilesets).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Releases to PyPi are handled via TravisCI and GitHub tags. Once changes have bee
 All tests are runnable with pytest. pytest is not installed by default and can be installed with the pip test extras
 
 ```shell
-pip install -e .[test]
+pip install -e '.[test]'
 ```
 
 Running tests

--- a/README.md
+++ b/README.md
@@ -12,15 +12,38 @@ CLI for interacting with and preparing data for the [Mapbox Tiling Service](http
 [CONTRIBUTING.md](/CONTRIBUTING.md) includes information about release processes & running tests. :raised_hands:
 
 # Installation
-`pip install mapbox-tilesets`
 
-#### Requirements
+## Requirements
 
 - Python >= 3.6 (can be installed via virtualenv)
 - Recommended: [virtualenv](https://virtualenv.pypa.io/) / [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/)
-- Windows only: binaries installed for [GDAL](http://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal) and [rasterio](http://www.lfd.uci.edu/~gohlke/pythonlibs/#rasterio) (note: Windows is not officially supported at this time)  
 
-#### Mapbox Access Tokens
+## Basic installation
+
+`pip install mapbox-tilesets` will install everything but [`estimate-area`](#estimate-area).
+## Installing optional `estimate-area` command
+If you are using an x86 Mac or Linux machine, run:
+`pip install 'mapbox-tilesets[estimate-area]'`
+
+Otherwise, you will need to install some dependencies.
+
+### arm64 MacOS
+If you're on an arm64 Mac (e.g., with an M1 chip), you'll need to install [GDAL](https://gdal.org/) first. On Mac, a simple way is to use [Homebrew](https://brew.sh/):
+```sh
+$ brew install gdal
+...
+$ pip install 'mapbox-tilesets[estimate-area]'
+```
+
+### Windows
+Note, Windows is not officially supported at this time.
+
+Windows users need to install [GDAL](http://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal) and [rasterio](http://www.lfd.uci.edu/~gohlke/pythonlibs/#rasterio).
+Then `pip install 'mapbox-tilesets[estimate-area]'`
+
+
+
+## Mapbox Access Tokens
 
 In order to use the tilesets endpoints, you need a Mapbox Access Token with `tilesets:write`, `tilesets:read`, and `tilesets:list` scopes. This is a secret token, so do not share it publicly!
 

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.7.3"
+__version__ = "1.7.3a1"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.7.3a1"
+__version__ = "1.7.3"

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -1,4 +1,5 @@
 """Tilesets command line interface"""
+import builtins
 import json
 import tempfile
 
@@ -9,8 +10,6 @@ from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
 import mapbox_tilesets
 from mapbox_tilesets import utils, errors
-from supermercado.super_utils import filter_features
-import builtins
 
 
 @click.version_option(version=mapbox_tilesets.__version__, message="%(version)s")
@@ -754,6 +753,8 @@ def estimate_area(features, precision, no_validation=False, force_1cm=False):
 
     features must be a list of paths to local files containing GeoJSON feature collections or feature sequences from argument or stdin, or a list of string-encoded coordinate pairs of the form "[lng, lat]", or "lng, lat", or "lng lat".
     """
+    filter_features = utils.load_module("supermercado.super_utils").filter_features
+
     area = 0
     if precision == "1cm" and not force_1cm:
         raise errors.TilesetsError(

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -747,7 +747,7 @@ def validate_stream(features):
     help="Enables 1cm precision",
 )
 def estimate_area(features, precision, no_validation=False, force_1cm=False):
-    """Estimate area of features with a precision level.
+    """Estimate area of features with a precision level. Requires extra installation steps: see https://github.com/mapbox/tilesets-cli/blob/master/README.md
 
     tilesets estimate-area <features> <precision>
 

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import re
 
@@ -5,9 +6,20 @@ import numpy as np
 
 from jsonschema import validate
 from requests import Session
-from supermercado.burntiles import burn
 
 import mapbox_tilesets
+
+
+def load_module(modulename):
+    """Dynamically imports a module and throws a readable exception if not found"""
+    try:
+        module = importlib.import_module(modulename)
+    except (ImportError):
+        raise ValueError(
+            f"Couldn't find {modulename}. Check installation steps in the readme for help."
+        ) from None
+
+    return module
 
 
 def _get_token(token=None):
@@ -206,6 +218,8 @@ def calculate_tiles_area(features, precision):
     -------
         total area of all tiles in square kilometers
     """
+    burn = load_module("supermercado.burntiles").burn
+
     zoom = _convert_precision_to_zoom(precision)
     tiles = burn(features, zoom)
     return np.sum(_calculate_tile_area(tiles))

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -16,7 +16,7 @@ def load_module(modulename):
         module = importlib.import_module(modulename)
     except (ImportError):
         raise ValueError(
-            f"Couldn't find {modulename}. Check installation steps in the readme for help."
+            f"Couldn't find {modulename}. Check installation steps in the readme for help: https://github.com/mapbox/tilesets-cli/blob/master/README.md"
         ) from None
 
     return module

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto3==1.9.99
 Click==7.1.2
 cligj==0.5.0
+numpy==1.22.2
 requests==2.21.0
 requests-toolbelt==0.9.1
 jsonschema==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.9.99
 Click==7.1.2
 cligj==0.5.0
-numpy==1.22.2
+numpy==1.19.5
 requests==2.21.0
 requests-toolbelt==0.9.1
 jsonschema==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -30,16 +30,19 @@ setup(
         "boto3",
         "click~=7.1.2",
         "cligj",
+        "numpy",
         "requests",
         "requests-toolbelt",
         "jsonschema~=3.0",
         "jsonseq~=1.0",
         "mercantile~=1.1.6",
-        "supermercado~=0.2.0",
     ],
     include_package_data=True,
     zip_safe=False,
     extras_require={
+        "estimate-area": [
+            "supermercado~=0.2.0",
+        ],
         "test": [
             "codecov",
             "pytest==4.6.11",
@@ -47,8 +50,9 @@ setup(
             "pre-commit",
             "black==20.8b1",
             "pep8",
+            "supermercado~=0.2.0",
             "toml==0.10.2",
-        ]
+        ],
     },
     entry_points="""
       [console_scripts]


### PR DESCRIPTION
fixes #147 

This makes `estimate-area` an optional command. This command depends on rasterio w/GDAL, which is not as easily installed on arm64 Macs. So, this PR enables a simple installation for most uses while still keeping this command available.

## testing

This shows the basic installation without estimate-area. We see the command fails with an exception.

```sh
$ pyenv activate env1
$ pip install mapbox-tilesets==1.7.3a1
    Collecting mapbox-tilesets==1.7.3a1
    Downloading mapbox_tilesets-1.7.3a1-py3-none-any.whl (15 kB)
    ...

$ tilesets --version
    1.7.3a1

$ tilesets list <account>
  ... list of tilesets

$ tilesets estimate-area valid.ldgeojson  -p 10m
    Traceback (most recent call last):
    File "/Users/johnklancer/.pyenv/versions/fresh/bin/tilesets", line 8, in <module>
        sys.exit(cli())
    File "/Users/johnklancer/.pyenv/versions/3.9.10/envs/fresh/lib/python3.9/site-packages/click/core.py", line 829, in __call__
        return self.main(*args, **kwargs)
    File "/Users/johnklancer/.pyenv/versions/3.9.10/envs/fresh/lib/python3.9/site-packages/click/core.py", line 782, in main
        rv = self.invoke(ctx)
    File "/Users/johnklancer/.pyenv/versions/3.9.10/envs/fresh/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
        return _process_result(sub_ctx.command.invoke(sub_ctx))
    File "/Users/johnklancer/.pyenv/versions/3.9.10/envs/fresh/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
        return ctx.invoke(self.callback, **ctx.params)
    File "/Users/johnklancer/.pyenv/versions/3.9.10/envs/fresh/lib/python3.9/site-packages/click/core.py", line 610, in invoke
        return callback(*args, **kwargs)
    File "/Users/johnklancer/.pyenv/versions/3.9.10/envs/fresh/lib/python3.9/site-packages/mapbox_tilesets/scripts/cli.py", line 756, in estimate_area
        filter_features = utils.load_module("supermercado.super_utils").filter_features
    File "/Users/johnklancer/.pyenv/versions/3.9.10/envs/fresh/lib/python3.9/site-packages/mapbox_tilesets/utils.py", line 18, in load_module
        raise ValueError(
    ValueError: Couldn't find supermercado.super_utils. Check installation steps in the readme for help.
```

This test shows the full installation including estimate-area. Testing on an M1 with `brew install gdal` already run.

```sh
$ pyenv activate env2
$ pip install 'mapbox-tilesets[estimate-area]'==1.7.3a1
Collecting mapbox-tilesets[estimate-area]==1.7.3a1
    ...
$ tilesets estimate-area valid.ldgeojson  -p 10m
{"km2": "382565", "precision": "10m", "pricing_docs": "For more information, visit https://www.mapbox.com/pricing/#tilesets"}
```

### After review
Once this is merged, I will bump the version to 1.7.3, tag, and verify it's published.