### PR TITLE
Update importlib-metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - '3.6'
   - '3.7'
 install:
+  - pip install -U setuptools
   - pip install -r requirements.txt -e .[test]
 script:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - '3.6'
   - '3.7'
 install:
-  - pip install -U setuptools
+  - pip install -U setuptools importlib-metadata
   - pip install -r requirements.txt -e .[test]
 script:
   - python --version


### PR DESCRIPTION
Builds are failing on python 3.7.1 (travis's 3.7.x default) due to importlib-metadata issues that are partially explained in https://github.com/pypa/setuptools/issues/3293

Quick fix is to install the latest version of importlib-metadata before installing other dependencies.

cc @Pshrawani 