### PR TITLE
add validation for linear ring being closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 =======
 
+# 1.8.0 (2022-08-25)
+- validates source in `upload-source` command using geojson library.
+- Provides line number for an invalid feature that is detected with the geojson validator.
+
 # 1.7.4 (2022-07-13)
 - validates source id for correct syntax when `upload-source` command to resolve `Connection reset by peer error`
 

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.7.4"
+__version__ = "1.8.0"

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -504,8 +504,8 @@ def validate_source(features):
     """
     click.echo("Validating features", err=True)
 
-    for feature in features:
-        utils.validate_geojson(feature)
+    for count, feature in enumerate(features):
+        utils.validate_geojson(count, feature)
 
     click.echo("✔ valid")
 
@@ -582,9 +582,9 @@ def _upload_source(
             )
 
     with tempfile.TemporaryFile() as file:
-        for feature in features:
+        for count, feature in enumerate(features):
             if not no_validation:
-                utils.validate_geojson(feature)
+                utils.validate_geojson(count, feature)
 
             file.write(
                 (json.dumps(feature, separators=(",", ":")) + "\n").encode("utf-8")
@@ -730,8 +730,8 @@ def list_sources(username, token=None):
 
 
 def validate_stream(features):
-    for feature in features:
-        utils.validate_geojson(feature)
+    for count, feature in enumerate(features):
+        utils.validate_geojson(count, feature)
         yield feature
 
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -504,8 +504,8 @@ def validate_source(features):
     """
     click.echo("Validating features", err=True)
 
-    for count, feature in enumerate(features):
-        utils.validate_geojson(count, feature)
+    for index, feature in enumerate(features):
+        utils.validate_geojson(index, feature)
 
     click.echo("✔ valid")
 
@@ -582,9 +582,9 @@ def _upload_source(
             )
 
     with tempfile.TemporaryFile() as file:
-        for count, feature in enumerate(features):
+        for index, feature in enumerate(features):
             if not no_validation:
-                utils.validate_geojson(count, feature)
+                utils.validate_geojson(index, feature)
 
             file.write(
                 (json.dumps(feature, separators=(",", ":")) + "\n").encode("utf-8")
@@ -730,8 +730,8 @@ def list_sources(username, token=None):
 
 
 def validate_stream(features):
-    for count, feature in enumerate(features):
-        utils.validate_geojson(count, feature)
+    for index, feature in enumerate(features):
+        utils.validate_geojson(index, feature)
         yield feature
 
 

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -71,15 +71,17 @@ def validate_tileset_id(tileset_id):
     return re.match(pattern, tileset_id, flags=re.IGNORECASE)
 
 
-def validate_linear_ring(geometry):
+def validate_linear_ring(count, geometry):
     if geometry['type'] == 'Polygon':
         coord = geometry['coordinates']
         is_ring = all([elem[0] == elem[-1] for elem in coord])
         if is_ring is False:
-            raise mapbox_tilesets.errors.TilesetsError('The first and last coordinates in a LinearRing must be equivalent')
+            raise mapbox_tilesets.errors.TilesetsError(
+                f"Error in feature number {count}: The first and last coordinates in a LinearRing must be equivalent"
+            )
 
 
-def validate_geojson(feature):
+def validate_geojson(count, feature):
     schema = {
         "definitions": {},
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -125,7 +127,7 @@ def validate_geojson(feature):
         },
     }
 
-    validate_linear_ring(feature['geometry'])
+    validate_linear_ring(count, feature['geometry'])
     return validate(instance=feature, schema=schema)
 
 

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -11,6 +11,7 @@ import mapbox_tilesets
 import geojson
 import json
 
+
 def load_module(modulename):
     """Dynamically imports a module and throws a readable exception if not found"""
     try:
@@ -72,6 +73,14 @@ def validate_tileset_id(tileset_id):
     return re.match(pattern, tileset_id, flags=re.IGNORECASE)
 
 
+def geojson_validate(index, feature):
+    geojsonFeature = geojson.loads(json.dumps(feature))
+    if not geojsonFeature.is_valid:
+        raise mapbox_tilesets.errors.TilesetsError(
+            f"Error in feature number {index}: " + "".join(geojsonFeature.errors())
+        )
+
+
 def validate_geojson(index, feature):
     schema = {
         "definitions": {},
@@ -118,11 +127,7 @@ def validate_geojson(index, feature):
         },
     }
     validate(instance=feature, schema=schema)
-    geojsonFeature = geojson.loads(json.dumps(feature))
-    if not geojsonFeature.is_valid:
-        raise mapbox_tilesets.errors.TilesetsError(f"Error in feature number {index}: " + ''.join(geojsonFeature.errors()))
-
-    return
+    geojson_validate(index, feature)
 
 
 def _convert_precision_to_zoom(precision):

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -71,6 +71,14 @@ def validate_tileset_id(tileset_id):
     return re.match(pattern, tileset_id, flags=re.IGNORECASE)
 
 
+def validate_linear_ring(geometry):
+    if geometry['type'] == 'Polygon':
+        coord = geometry['coordinates']
+        is_ring = all([elem[0] == elem[-1] for elem in coord])
+        if is_ring is False:
+            raise mapbox_tilesets.errors.TilesetsError('The first and last coordinates in a LinearRing must be equivalent')
+
+
 def validate_geojson(feature):
     schema = {
         "definitions": {},
@@ -117,6 +125,7 @@ def validate_geojson(feature):
         },
     }
 
+    validate_linear_ring(feature['geometry'])
     return validate(instance=feature, schema=schema)
 
 

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -72,8 +72,8 @@ def validate_tileset_id(tileset_id):
 
 
 def validate_linear_ring(count, geometry):
-    if geometry['type'] == 'Polygon':
-        coord = geometry['coordinates']
+    if geometry["type"] == "Polygon":
+        coord = geometry["coordinates"]
         is_ring = all([elem[0] == elem[-1] for elem in coord])
         if is_ring is False:
             raise mapbox_tilesets.errors.TilesetsError(
@@ -127,7 +127,7 @@ def validate_geojson(count, feature):
         },
     }
 
-    validate_linear_ring(count, feature['geometry'])
+    validate_linear_ring(count, feature["geometry"])
     return validate(instance=feature, schema=schema)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ jsonschema==3.0.1
 jsonseq==1.0.0
 mercantile==1.1.6
 supermercado==0.2.0
+geojson===2.5.0

--- a/tests/fixtures/invalid-polygon.ldgeojson
+++ b/tests/fixtures/invalid-polygon.ldgeojson
@@ -1,0 +1,16 @@
+{
+  "type": "Feature",
+  "id":"01",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [-150.957,-40.5948],
+        [-155,-41],
+        [-152,-42],
+        [-152, -40]
+      ]
+    ]
+  },
+  "properties":{"name":"Ducky Loo"}
+}

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -223,6 +223,7 @@ def test_cli_upload_source(
         == """upload progress\n{"id": "mapbox://tileset-source/test-user/populated-places-source"}\n"""
     )
 
+
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoder")
 @mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoderMonitor")
@@ -247,7 +248,11 @@ def test_cli_upload_source_not_closed_polygon(
     runner = CliRunner()
     validated_result = runner.invoke(
         upload_source,
-        ["test-user", "populated-places-source", "tests/fixtures/invalid-polygon.ldgeojson"],
+        [
+            "test-user",
+            "populated-places-source",
+            "tests/fixtures/invalid-polygon.ldgeojson",
+        ],
     )
     assert validated_result.exit_code == 1
 
@@ -255,6 +260,7 @@ def test_cli_upload_source_not_closed_polygon(
         str(validated_result.exception)
         == "Error in feature number 0: The first and last coordinates in a LinearRing must be equivalent"
     )
+
 
 @pytest.mark.usefixtures("token_environ")
 def validate_source_id(self):

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -253,7 +253,7 @@ def test_cli_upload_source_not_closed_polygon(
 
     assert (
         str(validated_result.exception)
-        == "The first and last coordinates in a LinearRing must be equivalent"
+        == "Error in feature number 0: The first and last coordinates in a LinearRing must be equivalent"
     )
 
 @pytest.mark.usefixtures("token_environ")

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -234,9 +234,6 @@ def test_cli_upload_source_not_closed_polygon(
     MockResponse,
     MockMultipartEncoding,
 ):
-    okay_response = {"id": "mapbox://tileset-source/test-user/populated-places-source"}
-    mock_request_post.return_value = MockResponse(okay_response, status_code=200)
-
     expected_json = b'{"type":"Feature","id":"01","geometry":{"type":"Polygon","coordinates":[[-150.957,-40.5948],[-155,-41],[-152,-42],[-152,-40]]},"properties":{"name":"Ducky Loo"}}\n'
 
     def side_effect(fields):

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -258,7 +258,7 @@ def test_cli_upload_source_not_closed_polygon(
 
     assert (
         str(validated_result.exception)
-        == "Error in feature number 0: The first and last coordinates in a LinearRing must be equivalent"
+        == "Error in feature number 0: Each linear ring must end where it started"
     )
 
 

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -228,7 +228,7 @@ def test_cli_upload_source(
 @mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoder")
 @mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoderMonitor")
 @mock.patch("requests.Session.post")
-def test_cli_upload_source_not_closed_polygon(
+def test_cli_upload_source_invalid_polygon(
     mock_request_post,
     mock_multipart_encoder,
     MockResponse,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ from mapbox_tilesets.utils import (
     _get_api,
     _get_session,
     _get_token,
-    validate_linear_ring,
     validate_tileset_id,
     _convert_precision_to_zoom,
     calculate_tiles_area,
@@ -69,17 +68,6 @@ def test_validate_tileset_id_toolong():
     tileset = "hellooooooooooooooooooooooooooooooo.hiiiiiiiuuuuuuuuuuuuuuuuuuuuuu"
 
     assert not validate_tileset_id(tileset)
-
-
-def test_validate_linear_ring():
-    geometry = {"type": "Polygon", "coordinates": [[[1, 2], [3, 4], [5, 6]]]}
-    with pytest.raises(TilesetsError) as excinfo:
-        validate_linear_ring(2, geometry)
-
-    assert (
-        str(excinfo.value)
-        == "Error in feature number 2: The first and last coordinates in a LinearRing must be equivalent"
-    )
 
 
 def test_convert_precision_to_zoom_10m():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,11 +74,11 @@ def test_validate_tileset_id_toolong():
 def test_validate_linear_ring():
     geometry = { 'type': 'Polygon', 'coordinates': [[[1, 2], [3, 4], [5, 6]]]}
     with pytest.raises(TilesetsError) as excinfo:
-        validate_linear_ring(geometry)
+        validate_linear_ring(2, geometry)
 
     assert (
         str(excinfo.value)
-        == "The first and last coordinates in a LinearRing must be equivalent"
+        == "Error in feature number 2: The first and last coordinates in a LinearRing must be equivalent"
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from mapbox_tilesets.utils import (
     _get_api,
     _get_session,
     _get_token,
+    validate_linear_ring,
     validate_tileset_id,
     _convert_precision_to_zoom,
     calculate_tiles_area,
@@ -68,6 +69,17 @@ def test_validate_tileset_id_toolong():
     tileset = "hellooooooooooooooooooooooooooooooo.hiiiiiiiuuuuuuuuuuuuuuuuuuuuuu"
 
     assert not validate_tileset_id(tileset)
+
+
+def test_validate_linear_ring():
+    geometry = { 'type': 'Polygon', 'coordinates': [[[1, 2], [3, 4], [5, 6]]]}
+    with pytest.raises(TilesetsError) as excinfo:
+        validate_linear_ring(geometry)
+
+    assert (
+        str(excinfo.value)
+        == "The first and last coordinates in a LinearRing must be equivalent"
+    )
 
 
 def test_convert_precision_to_zoom_10m():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,7 +81,8 @@ def test_geojson_validate():
         == "Error in feature number 2: Each linear ring must contain at least 4 positions"
     )
 
-def test_geojson_validate_closed_ring():
+
+def test_geojson_validate_open_ring():
     geometry = {"type": "Polygon", "coordinates": [[[1, 2], [3, 4], [5, 6], [7, 8]]]}
     with pytest.raises(TilesetsError) as excinfo:
         geojson_validate(2, geometry)
@@ -90,6 +91,27 @@ def test_geojson_validate_closed_ring():
         str(excinfo.value)
         == "Error in feature number 2: Each linear ring must end where it started"
     )
+
+
+def test_geojson_validate_closed_ring():
+    geometry = {"type": "Polygon", "coordinates": [[[1, 2], [3, 4], [5, 6], [1, 2]]]}
+    assert geojson_validate(2, geometry) is None
+
+
+def test_geojson_validate_closed_ring_correct_winding_order():
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+    }
+    assert geojson_validate(2, geometry) is None
+
+
+def test_geojson_validate_closed_ring_incorrect_winding_order():
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [1, 0], [0, 1], [1, 1], [0, 0]]],
+    }
+    assert geojson_validate(2, geometry) is None
 
 
 def test_convert_precision_to_zoom_10m():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from mapbox_tilesets.utils import (
     _get_api,
     _get_session,
     _get_token,
+    geojson_validate,
     validate_tileset_id,
     _convert_precision_to_zoom,
     calculate_tiles_area,
@@ -68,6 +69,17 @@ def test_validate_tileset_id_toolong():
     tileset = "hellooooooooooooooooooooooooooooooo.hiiiiiiiuuuuuuuuuuuuuuuuuuuuuu"
 
     assert not validate_tileset_id(tileset)
+
+
+def test_geojson_validate():
+    geometry = {"type": "Polygon", "coordinates": [[[1, 2], [3, 4], [5, 6]]]}
+    with pytest.raises(TilesetsError) as excinfo:
+        geojson_validate(2, geometry)
+
+    assert (
+        str(excinfo.value)
+        == "Error in feature number 2: Each linear ring must contain at least 4 positions"
+    )
 
 
 def test_convert_precision_to_zoom_10m():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,7 +72,7 @@ def test_validate_tileset_id_toolong():
 
 
 def test_validate_linear_ring():
-    geometry = { 'type': 'Polygon', 'coordinates': [[[1, 2], [3, 4], [5, 6]]]}
+    geometry = {"type": "Polygon", "coordinates": [[[1, 2], [3, 4], [5, 6]]]}
     with pytest.raises(TilesetsError) as excinfo:
         validate_linear_ring(2, geometry)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,6 +81,16 @@ def test_geojson_validate():
         == "Error in feature number 2: Each linear ring must contain at least 4 positions"
     )
 
+def test_geojson_validate_closed_ring():
+    geometry = {"type": "Polygon", "coordinates": [[[1, 2], [3, 4], [5, 6], [7, 8]]]}
+    with pytest.raises(TilesetsError) as excinfo:
+        geojson_validate(2, geometry)
+
+    assert (
+        str(excinfo.value)
+        == "Error in feature number 2: Each linear ring must end where it started"
+    )
+
 
 def test_convert_precision_to_zoom_10m():
     precision = "10m"


### PR DESCRIPTION
Closes #155 

error message for when a linear ring is not closed:
`Error in feature number 3: The first and last coordinates in a LinearRing must be equivalent`

### Manual test result
```
tilesets upload-source sofiapaganin  hahaha ./tests/fixtures/invalid-polygon.ldgeojson
```
![image](https://user-images.githubusercontent.com/31298051/186774641-b0b76821-6621-4f7d-915c-9acfe04ce36e.png)
