### PR TITLE
Fix `geojson` package installation in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.8.1 (2022-08-25)
+- Bug Fix: Fix setup script to have `geojson` package in install requirements
+
 # 1.8.0 (2022-08-25)
 - validates source in `upload-source` command using geojson library.
 - Provides line number for an invalid feature that is detected with the geojson validator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 =======
 
-# 1.8.1 (2022-08-25)
+# 1.8.1 (2022-08-29)
 - Bug Fix: Fix setup script to have `geojson` package in install requirements
 
 # 1.8.0 (2022-08-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 =======
 
 # 1.8.1 (2022-08-29)
-- Bug Fix: Fix setup script to have `geojson` package in install requirements
+- Bug Fix: Fix setup script to have `geojson` package in setup.py install requirements
 
-# 1.8.0 (2022-08-25)
-- validates source in `upload-source` command using geojson library.
+# 1.8.0 (2022-08-25) - [YANKED]
+
+*Yanked due to missing `geojson` package in setup.py*
+
+- Validates source in `upload-source` command using [geojson package](https://github.com/jazzband/geojson).
 - Provides line number for an invalid feature that is detected with the geojson validator.
 
 # 1.7.4 (2022-07-13)
-- validates source id for correct syntax when `upload-source` command to resolve `Connection reset by peer error`
+- Validates source id for correct syntax when `upload-source` command to resolve `Connection reset by peer error`
 
 # 1.7.3 (2022-03-14)
  - Loads `supermercado` on request because binaries for arm64 MacOS and Windows are not easily available.

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "jsonschema~=3.0",
         "jsonseq~=1.0",
         "mercantile~=1.1.6",
+        "geojson~=2.5.0",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
## Summary
This PR fixes the bug for install requirements for the `geojson` which were missing in the latest `1.8.0` version after merging this [PR](https://github.com/mapbox/tilesets-cli/pull/167)