### PR TITLE
Add command for tilesets activity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
-    -
-        repo: 'https://github.com/ambv/black'
-        # 18.6b1
-        rev: 22.3.0
-        hooks:
-            - id: black
-              args: ['--safe']
-    -
-        repo: 'https://gitlab.com/pycqa/flake8'
-        rev: 3.9.0
-        hooks:
-            - id: flake8
-              args: [
-                  # E501 let black handle all line length decisions
-                  # W503 black conflicts with "line break before operator" rule
-                  # E203 black conflicts with "whitespace before ':'" rule
-                  # E722 bare excepts need to be addressed
-                  '--ignore=E501,W503,E203,E722']
+  -
+    repo: 'https://github.com/ambv/black'
+    # 18.6b1
+    rev: 22.3.0
+    hooks:
+      - id: black
+        args: ['--safe']
+  -
+    repo: 'https://github.com/PyCQA/flake8'
+    rev: 3.9.0
+    hooks:
+      - id: flake8
+        args: [
+          # E501 let black handle all line length decisions
+          # W503 black conflicts with "line break before operator" rule
+          # E203 black conflicts with "whitespace before ':'" rule
+          # E722 bare excepts need to be addressed
+          '--ignore=E501,W503,E203,E722']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         args: ['--safe']
   -
     repo: 'https://github.com/PyCQA/flake8'
-    rev: 3.9.0
+    rev: 5.0.4
     hooks:
       - id: flake8
         args: [

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - '3.6'
   - '3.7'
 install:
-  - pip install -U setuptools importlib-metadata
+  - pip install -U setuptools "importlib-metadata==4.8.3"
   - pip install -r requirements.txt -e .[test]
 script:
   - python --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.9.0 (2023-06-14)
+- Added command `tilesets list-activity` that returns activity data for a user's tilesets
+
 # 1.8.1 (2022-08-29)
 - Bug Fix: Fix setup script to have `geojson` package in setup.py install requirements
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ export MAPBOX_ACCESS_TOKEN=my.token
   * [`jobs`](#jobs)
   * [`list`](#list)
   * [`tilejson`](#tilejson)
+* Activity
+  * [`list-activity`](#list-activity)
 
 ### upload-source
 
@@ -401,3 +403,19 @@ tilesets tilejson <tileset_id>
 Flags:
 
 * `--secure`: By default, resource URLs in the retrieved TileJSON (such as in the "tiles" array) will use the HTTP scheme. Include this query parameter in your request to receive HTTPS resource URLs instead.
+
+### list-activity
+
+List tileset activity for an account. Returns a pagination key `next` if there are more results than the return limit that can be passed into another command as the `start` argument.
+
+```shell
+tilesets list-activity <account>
+```
+
+Flags:
+
+* `--sortby [requests|modified]` [optional]: Sorting key (default: requests)
+* `--orderby [asc|desc]` [optional]: Ordering key (default: desc)
+* `--limit [1-500]` [optional]: The maximum number of results to return (default: 100)
+* `--indent` [optional]: Indent size for JSON output.
+* `--start` [optional]: Pagination key from the `next` value in a response that has more results than the limit.

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Flags:
 
 ### list-activity
 
-List tileset activity for an account. Returns a pagination key `next` if there are more results than the return limit that can be passed into another command as the `start` argument.
+Lists total request counts for a user's tilesets in the past 30 days. Returns a pagination key `next` if there are more results than the return limit that can be passed into another command as the `start` argument.
 
 ```shell
 tilesets list-activity <account>

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.8.1"
+__version__ = "1.9.0"

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -2,6 +2,7 @@
 import builtins
 import json
 import tempfile
+from urllib.parse import urlencode, urlparse, parse_qs
 
 import click
 import cligj
@@ -799,3 +800,78 @@ def estimate_area(features, precision, no_validation=False, force_1cm=False):
             }
         )
     )
+
+
+@cli.command("list-activity")
+@click.argument("username", required=True, type=str)
+@click.option(
+    "--sortby",
+    required=False,
+    type=click.Choice(["requests", "modified"]),
+    default="requests",
+    help="Sort the results by request count or modified timestamps (default: 'requests')",
+)
+@click.option(
+    "--orderby",
+    required=False,
+    type=click.Choice(["asc", "desc"]),
+    default="desc",
+    help="Order results by asc or desc for the sort key (default: 'desc')",
+)
+@click.option(
+    "--limit",
+    required=False,
+    type=click.IntRange(1, 500),
+    default=100,
+    help="The maximum number of results to return, from 1 to 500 (default: 100)",
+)
+@click.option(
+    "--start",
+    required=False,
+    type=str,
+    help="Pagination key from the `next` value in a response that has more results than the limit.",
+)
+@click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
+@click.option("--indent", type=int, default=None, help="Indent for JSON output")
+def list_activity(
+    username,
+    sortby=None,
+    orderby=None,
+    limit=None,
+    start=None,
+    token=None,
+    indent=None,
+):
+    """List tileset activity for an account. Response is an ordered array of aggregate resource data.
+
+    tilesets list-activity <username>
+    """
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
+
+    params = {
+        "access_token": token,
+        "sortby": sortby,
+        "orderby": orderby,
+        "limit": limit,
+        "start": start,
+    }
+    params = {k: v for k, v in params.items() if v}
+    query_string = urlencode(params)
+    url = f"{mapbox_api}/activity/v1/{username}/tilesets?{query_string}"
+
+    r = s.get(url)
+    if r.status_code == 200:
+        if r.headers.get("Link"):
+            url = re.findall(r"<(.*)>;", r.headers.get("Link"))[0]
+            query = urlparse(url).query
+            start = parse_qs(query)["start"][0]
+
+        result = {
+            "data": r.json(),
+            "next": start,
+        }
+        click.echo(json.dumps(result, indent=indent))
+    else:
+        raise errors.TilesetsError(r.text)

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -842,7 +842,9 @@ def list_activity(
     token=None,
     indent=None,
 ):
-    """List tileset activity for an account. Response is an ordered array of aggregate resource data.
+    """List tileset activity for an account. The response is an ordered array of data about the user's tilesets and their
+    total requests over the past 30 days. The sorting and ordering can be configured through cli arguments, defaulting to
+    descending request counts.
 
     tilesets list-activity <username>
     """

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -851,7 +851,7 @@ def list_activity(
     s = utils._get_session()
 
     params = {
-        "access_token": token,
+        "access_token": mapbox_token,
         "sortby": sortby,
         "orderby": orderby,
         "limit": limit,

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -16,7 +16,7 @@ def load_module(modulename):
     """Dynamically imports a module and throws a readable exception if not found"""
     try:
         module = importlib.import_module(modulename)
-    except (ImportError):
+    except ImportError:
         raise ValueError(
             f"Couldn't find {modulename}. Check installation steps in the readme for help: https://github.com/mapbox/tilesets-cli/blob/master/README.md"
         ) from None

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         ],
         "test": [
             "codecov",
-            "pytest==4.6.11",
+            "pytest==6.2.5",
             "pytest-cov",
             "pre-commit",
             "black==22.3.0",

--- a/tests/test_cli_activity.py
+++ b/tests/test_cli_activity.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 
 from mapbox_tilesets.scripts.cli import list_activity
 
-DEFAULT_ENDPOINT = "https://api.mapbox.com/activity/v1/test/tilesets?sortby=requests&orderby=desc&limit=100"
+DEFAULT_ENDPOINT = "https://api.mapbox.com/activity/v1/test/tilesets?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&sortby=requests&orderby=desc&limit=100"
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -75,7 +75,7 @@ def test_cli_list_activity_arguments_valid(mock_request_get, MockResponse):
     )
     # Arguments are passed into the query string
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/activity/v1/test/tilesets?sortby=modified&orderby=asc&limit=5&start=foo"
+        "https://api.mapbox.com/activity/v1/test/tilesets?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&sortby=modified&orderby=asc&limit=5&start=foo"
     )
 
 

--- a/tests/test_cli_activity.py
+++ b/tests/test_cli_activity.py
@@ -1,0 +1,100 @@
+import json
+import pytest
+
+from unittest import mock
+
+from click.testing import CliRunner
+
+from mapbox_tilesets.scripts.cli import list_activity
+
+DEFAULT_ENDPOINT = "https://api.mapbox.com/activity/v1/test/tilesets?sortby=requests&orderby=desc&limit=100"
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_activity(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = [
+        {
+            "id": "penny.map-one",
+            "request_count": 500,
+            "last_modified": "2023-06-14T20:18:54.809Z",
+        },
+        {
+            "id": "penny.map-two",
+            "request_count": 400,
+            "last_modified": "2023-06-14T20:18:54.809Z",
+        },
+        {
+            "id": "penny.map-three",
+            "request_count": 300,
+            "last_modified": "2023-06-14T20:18:54.809Z",
+        },
+    ]
+    # sends expected request
+    mock_request_get.return_value = MockResponse(message)
+    MockResponse.headers = {"Link": '<meow.com?start=foo>; rel="next"'}
+    result = runner.invoke(list_activity, ["test"])
+    mock_request_get.assert_called_with(DEFAULT_ENDPOINT)
+    assert json.loads(result.output) == {"data": message, "next": "foo"}
+    assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_activity_bad_token(mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    message = {"message": "Not Found"}
+    # sends expected request
+    mock_request_get.return_value = MockResponse(message, status_code=404)
+    result = runner.invoke(list_activity, ["test"])
+    mock_request_get.assert_called_with(DEFAULT_ENDPOINT)
+    assert result.exit_code == 1
+    assert result.exception
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+def test_cli_list_activity_arguments_valid(mock_request_get, MockResponse):
+    runner = CliRunner()
+    result = runner.invoke(
+        list_activity,
+        [
+            "test",
+            "--sortby",
+            "modified",
+            "--orderby",
+            "asc",
+            "--limit",
+            "5",
+            "--start",
+            "foo",
+        ],
+    )
+    # Arguments are passed into the query string
+    mock_request_get.assert_called_with(
+        "https://api.mapbox.com/activity/v1/test/tilesets?sortby=modified&orderby=asc&limit=5&start=foo"
+    )
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.get")
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        (["--sortby", "likes"]),
+        (["--orderby", "chaos"]),
+        (["--limit", "0"]),
+        (["--limit", "501"]),
+    ],
+)
+def test_cli_list_activity_arguments_invalid(
+    mock_request_get, MockResponse, extra_args
+):
+    runner = CliRunner()
+    result = runner.invoke(list_activity, ["test"] + extra_args)
+    # Invalid argument values should error
+    mock_request_get.assert_not_called()
+    assert result.exit_code == 2

--- a/tests/test_cli_activity.py
+++ b/tests/test_cli_activity.py
@@ -59,7 +59,7 @@ def test_cli_list_activity_bad_token(mock_request_get, MockResponse):
 @mock.patch("requests.Session.get")
 def test_cli_list_activity_arguments_valid(mock_request_get, MockResponse):
     runner = CliRunner()
-    result = runner.invoke(
+    runner.invoke(
         list_activity,
         [
             "test",


### PR DESCRIPTION
## Details

- Added a command to list activity data for the requesting user's tilesets
- Some misc updates to make Travis happy

To-do:
- [ ] `git tag -a v1.9.0 -m 'v1.9.0' && git push --tags`
- [ ] Confirm release at https://pypi.org/project/mapbox-tilesets/#history

## Tests
_Installed locally_

### Basic command success
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/380d5b9d-a706-43c4-9770-69d2e7bd17d7)
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/75bbf112-7b40-4390-911f-734bb649d07a)

### Unauthorized failures
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/67c4963e-9411-4b8a-bc1a-4d6316379122)
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/dfa4aaf8-36f7-44b0-871f-be4477365b55)

### Invalid argument value failures
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/37a55845-5372-482e-9d5c-fe75fa942cd5)
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/cbc2f49e-f131-4f5e-80f9-06c9273b1b0a)
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/b43a9397-4b17-4c79-9233-2106d8de54e2)
