### PR TITLE
Pin urllib3, bump requests and boto3 due to OpenSSL issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.9.1 (2023-06-21)
+- Pin urllib3 version, see: https://github.com/urllib3/urllib3/issues/2168
+
 # 1.9.0 (2023-06-14)
 - Added command `tilesets list-activity` that returns activity data for a user's tilesets
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
-boto3==1.9.99
+boto3==1.23.10
 Click==8.0.2
 cligj==0.7.2
 numpy==1.19.5
-requests==2.21.0
+requests==2.27.1
 requests-toolbelt==0.9.1
 jsonschema==3.0.1
 jsonseq==1.0.0
 mercantile==1.1.6
 supermercado==0.2.0
 geojson===2.5.0
+urllib3==1.26.16


### PR DESCRIPTION
Travis hit a build error after #174 was merged into master. This error wasn't seen before in the feature branch, but appeared during the deploy step in master.

```ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2g  1 Mar 2016'. See: https://github.com/urllib3/urllib3/issues/2168```

- It looks like we need to pin `urllib3` to < 2.0. This change pins it to v1.26.16 as it's the latest version available that's < v2.0. 
  - https://github.com/urllib3/urllib3/tags
- `requests` and `boto3` (by way of `botocore`)also needed to be bumped because they had incompatible `urllib3` version requirements.

  - https://github.com/psf/requests/blob/v2.27.1/setup.py#LL48C5-L48C28
  - https://github.com/boto/botocore/blob/1.23.10/setup.py#L28
  
- `urllib3` v2.0.3 was being install via twine
```
Collecting urllib3>=1.26.0 (from twine)
Downloading urllib3-2.0.3-py3-none-any.whl (123 kB)
  ```
  - The newly pinned version still satisfies this requirement
