### PR TITLE
Use Bionic dist instead of default Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: bionic
 python:
   - '3.6'
   - '3.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.9.2 (2023-06-21)
+- Use Bionic dist instead of Xenial for Travis build
+
 # 1.9.1 (2023-06-21)
 - Pin urllib3 version, see: https://github.com/urllib3/urllib3/issues/2168
 


### PR DESCRIPTION
[TravisCI DPL](https://github.com/travis-ci/dpl) has a version dependency for urllib3 that requires OpenSSL 1.1.1+, causing our builds to fail due to us having 1.0.2g
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/7f65bbdd-051f-498b-a22d-3a85e61de098)

---

Our Travis config currently doesn't specify a dist so it defaults to Xenial (Ubuntu 16.04), which comes with OpenSSL 1.0.2g.
  - https://launchpad.net/ubuntu/xenial/+source/openssl
  - ![image](https://github.com/mapbox/tilesets-cli/assets/38864262/d9d32ac1-18bf-488a-a5b1-1bcdaa3097ad)
  - Confirmed by our Travis build logs
  ![image](https://github.com/mapbox/tilesets-cli/assets/38864262/11e29f40-9e3a-49d5-a46b-dc3e25e24858)
  ![image](https://github.com/mapbox/tilesets-cli/assets/38864262/bc64ff53-aacf-4a0c-9823-e98bd1bed59f)
  
---

If we use Bionic (Ubuntu 18.04) we should get OpenSSL 1.1.1.
- https://launchpad.net/ubuntu/bionic/+source/openssl
- ![image](https://github.com/mapbox/tilesets-cli/assets/38864262/55d7b714-9725-4e26-ad73-9f361636afab)
- Confirmed in our Travis build Logs
  ![image](https://github.com/mapbox/tilesets-cli/assets/38864262/26d3c1c8-242c-43b4-bdda-8034cc26db83)
  ![image](https://github.com/mapbox/tilesets-cli/assets/38864262/1e26db1d-2b4c-4f10-9423-e1a43df963ea)

---

Also confirmed in TravisCI docs that the Python version we build with is supported by the new dist
https://docs.travis-ci.com/user/languages/python/#python-versions
