### PR TITLE
Beautify Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.9.3 (2023-06-27)
+- Beautified error messages
+
 # 1.9.2 (2023-06-21)
 - Use Bionic dist instead of Xenial for Travis build
 

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.9.0"
+__version__ = "1.9.3"

--- a/mapbox_tilesets/errors.py
+++ b/mapbox_tilesets/errors.py
@@ -1,6 +1,5 @@
 """Error handling for the tilesets CLI"""
 from click import ClickException
-from jsonschema.exceptions import ValidationError
 
 
 class TilesetsError(ClickException):

--- a/mapbox_tilesets/errors.py
+++ b/mapbox_tilesets/errors.py
@@ -1,7 +1,9 @@
 """Error handling for the tilesets CLI"""
+from click import ClickException
+from jsonschema.exceptions import ValidationError
 
 
-class TilesetsError(Exception):
+class TilesetsError(ClickException):
     """Base Tilesets error
     Deriving errors from this base isolates module development
     problems from Python usage problems.

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -4,7 +4,8 @@ import re
 
 import numpy as np
 
-from jsonschema import validate
+from click import ClickException
+from jsonschema import validate, ValidationError
 from requests import Session
 
 import mapbox_tilesets
@@ -126,7 +127,10 @@ def validate_geojson(index, feature):
             },
         },
     }
-    validate(instance=feature, schema=schema)
+    try:
+        validate(instance=feature, schema=schema)
+    except ValidationError as e:
+        raise ClickException(e)
     geojson_validate(index, feature)
 
 

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -5,7 +5,6 @@ from click.testing import CliRunner
 from unittest import mock
 
 from mapbox_tilesets.scripts.cli import delete
-from mapbox_tilesets.errors import TilesetsError
 
 
 class MockResponse:

--- a/tests/test_cli_delete.py
+++ b/tests/test_cli_delete.py
@@ -82,4 +82,4 @@ def test_cli_delete_fail(mock_request_delete):
         "https://api.mapbox.com/tilesets/v1/test.id?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 1
-    assert isinstance(result.exception, TilesetsError)
+    assert isinstance(result.exception, SystemExit)

--- a/tests/test_cli_estimate_area.py
+++ b/tests/test_cli_estimate_area.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
 from mapbox_tilesets.scripts.cli import estimate_area
+from utils import clean_runner_output
 
 
 # rainy day scenarios
@@ -11,7 +12,7 @@ def test_cli_estimate_area_features_from_invalid_stdin_geojson():
         estimate_area, ["--precision", "10m"], input="invalidGeoJson input"
     )
     assert invalidated_result.exit_code == 1
-    assert str(invalidated_result.exception) == message
+    assert clean_runner_output(invalidated_result.output) == message
 
 
 def test_cli_estimate_area_features_from_invalid_geojson_content():
@@ -21,7 +22,7 @@ def test_cli_estimate_area_features_from_invalid_geojson_content():
         estimate_area,
         ["tests/fixtures/invalid-geojson.ldgeojson", "--precision", "1m"],
     )
-    assert message in str(invalidated_result.exception)
+    assert message in str(invalidated_result.output)
     assert invalidated_result.exit_code == 1
 
 
@@ -32,7 +33,7 @@ def test_cli_estimate_area_features_from_nonexistent_geojson_file():
         estimate_area,
         ["tests/fixtures/nonexistent-geojson.ldgeojson", "--precision", "1m"],
     )
-    assert str(invalidated_result.exception) == message
+    assert clean_runner_output(invalidated_result.output) == message
     assert invalidated_result.exit_code == 1
 
 
@@ -64,7 +65,7 @@ def test_cli_estimate_area_1cm_precision_without_flag():
         ["tests/fixtures/valid.ldgeojson", "-p", "1cm"],
     )
     assert invalidated_result.exit_code == 1
-    assert str(invalidated_result.exception) == message
+    assert clean_runner_output(invalidated_result.output) == message
 
 
 def test_cli_estimate_area_invalid_1cm_precision_flag():
@@ -75,7 +76,7 @@ def test_cli_estimate_area_invalid_1cm_precision_flag():
         ["tests/fixtures/valid.ldgeojson", "-p", "1m", "--force-1cm"],
     )
     assert invalidated_result.exit_code == 1
-    assert str(invalidated_result.exception) == message
+    assert clean_runner_output(invalidated_result.output) == message
 
 
 # sunny day scenarios

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -14,6 +14,7 @@ from mapbox_tilesets.scripts.cli import (
     validate_source,
     list_sources,
 )
+from utils import clean_runner_output
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -73,7 +74,7 @@ def test_cli_add_source_wrong_username(
     assert validated_result.exit_code == 1
 
     assert (
-        str(validated_result.exception)
+        clean_runner_output(validated_result.output)
         == "Token username wrong-user does not match username test-user-wrong"
     )
 
@@ -91,7 +92,7 @@ def test_cli_add_source_no_token():
     assert unauthenticated_result.exit_code == 1
 
     assert (
-        str(unauthenticated_result.exception)
+        clean_runner_output(unauthenticated_result.output)
         == """No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag."""
     )
 
@@ -116,7 +117,7 @@ def test_cli_add_source_no_validation(mock_request_post, MockResponse):
     assert no_validation_result.exit_code == 1
 
     assert (
-        no_validation_result.exception.message
+        clean_runner_output(no_validation_result.output)
         == '{"message": "Invalid file format. Only GeoJSON features are allowed."}'
     )
 
@@ -254,7 +255,7 @@ def test_cli_upload_source_invalid_polygon(
     assert validated_result.exit_code == 1
 
     assert (
-        str(validated_result.exception)
+        clean_runner_output(validated_result.output)
         == "Error in feature number 0: Each linear ring must end where it started"
     )
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from unittest import mock
 
 from mapbox_tilesets.scripts.cli import status
-from mapbox_tilesets.errors import TilesetsError
+from utils import clean_runner_output
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -63,5 +63,5 @@ def test_cli_status_error(mock_request_get, MockResponse):
         "https://api.mapbox.com/tilesets/v1/test.id/jobs?limit=1&access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 1
-    assert isinstance(result.exception, TilesetsError)
-    assert result.exception.message == '{"message": "test.id has no jobs."}'
+    assert isinstance(result.exception, SystemExit)
+    assert clean_runner_output(result.output) == '{"message": "test.id has no jobs."}'

--- a/tests/test_cli_tilejson.py
+++ b/tests/test_cli_tilejson.py
@@ -4,6 +4,7 @@ from unittest import mock
 from click.testing import CliRunner
 from mapbox_tilesets.scripts.cli import tilejson
 from mapbox_tilesets.errors import TilesetsError, TilesetNameError
+from utils import clean_runner_output
 
 
 class MockResponse:
@@ -94,7 +95,7 @@ def test_cli_tilejson_error(mock_request_get, MockResponse):
         "https://api.mapbox.com/v4/test.id,test.another.json?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 1
-    assert isinstance(result.exception, TilesetsError)
+    assert isinstance(result.exception, SystemExit)
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -104,5 +105,5 @@ def test_cli_tilejson_invalid_tileset_id():
     # sends expected request
     result = runner.invoke(tilejson, ["invalid@@id"])
     assert result.exit_code == 1
-    assert isinstance(result.exception, TilesetNameError)
-    assert "invalid@@id" in str(result.exception)
+    assert isinstance(result.exception, SystemExit)
+    assert clean_runner_output(result.output) == "Invalid Tileset ID"

--- a/tests/test_cli_tilejson.py
+++ b/tests/test_cli_tilejson.py
@@ -3,7 +3,6 @@ import pytest
 from unittest import mock
 from click.testing import CliRunner
 from mapbox_tilesets.scripts.cli import tilejson
-from mapbox_tilesets.errors import TilesetsError, TilesetNameError
 from utils import clean_runner_output
 
 

--- a/tests/test_cli_view_recipe.py
+++ b/tests/test_cli_view_recipe.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 from unittest import mock
 
 from mapbox_tilesets.scripts.cli import view_recipe
+from utils import clean_runner_output
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -50,5 +51,4 @@ def test_cli_view_recipe_raises(mock_request_get, MockResponse):
         "https://api.mapbox.com/tilesets/v1/test.id/recipe?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K"
     )
     assert result.exit_code == 1
-
-    assert result.exception.message == '"not found"'
+    assert clean_runner_output(result.output) == '"not found"'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,5 @@
+
+def clean_runner_output(runner_output: str) -> str:
+    """Clean runner output for easier comparisons in tests"""
+    return runner_output.strip().split('Error: ')[-1]
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,3 @@
-
 def clean_runner_output(runner_output: str) -> str:
     """Clean runner output for easier comparisons in tests"""
-    return runner_output.strip().split('Error: ')[-1]
-
+    return runner_output.strip().split("Error: ")[-1]


### PR DESCRIPTION
## Context

This work removes confusing stack traces from error outputs.

## Tests

Some before/after spot tests

---
### Before: estimate-area, invalid geojson
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/ebac036d-58f8-4130-982a-e0681bdce71b)

### After: estimate-area, invalid geojson
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/4d01316a-591f-4c7a-84fc-c7d08ce06dea)

---
### Before: estimate-area, json schema validation error
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/cc25c170-4ec2-4d04-913d-3b9176719a15)

### After: estimate-area, json schema validation error
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/1eb0a580-0d2d-4506-a679-15d0ddb6ee02)

---

### Before: no token
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/2f0e5e55-9589-48f5-8f91-7a4cd0e2ddc5)

### After: no token
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/97317bd6-1672-4cf5-9f4f-e548a41476f7)

---
### Before: delete, tileset not found
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/cb4abf30-d97e-4bbe-bb8c-5cc0bde757a9)

### After: delete, tileset not found
![image](https://github.com/mapbox/tilesets-cli/assets/38864262/369f2f3e-533f-41bd-b146-ae5621ca593c)

