### PR TITLE
feat: add support for the rasterarray type on the list command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.10.0 (2024-05-07)
+- Add support for the `rasterarray` type on the `list` command.
+
 # 1.9.3 (2023-06-27)
 - Beautified error messages
 

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ tilesets list <username>
 
 Flags:
 
-- `--type [vector|raster]` [optional]: filter results by tileset type
+- `--type [vector|raster|rasterarray]` [optional]: filter results by tileset type
 - `--visibility [public|private]` [optional]: filter results by visibility
 - `--sortby [created|modified]` [optional]: sort results by their `created` or `modified` timestamps
 - `--limit [1-500]` [optional]: the maximum number of results to return, from 1 to 500. The default is 100.

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.9.3"
+__version__ = "1.10.0"

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -362,7 +362,7 @@ def job(tileset, job_id, token=None, indent=None):
 @click.option(
     "--type",
     required=False,
-    type=click.Choice(["vector", "raster"]),
+    type=click.Choice(["vector", "raster", "rasterarray"]),
     help="Filter results by tileset type",
 )
 @click.option(

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -67,7 +67,8 @@ def test_cli_list_bad_token(mock_request_get, MockResponse):
 
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.Session.get")
-def test_cli_list_type_vector(mock_request_get, MockResponse):
+@pytest.mark.parametrize("type", ["vector", "raster", "rasterarray"])
+def test_cli_list_type(mock_request_get, MockResponse, type):
     runner = CliRunner()
 
     message = [
@@ -76,28 +77,9 @@ def test_cli_list_type_vector(mock_request_get, MockResponse):
     ]
 
     mock_request_get.return_value = MockResponse(message)
-    result = runner.invoke(list, ["test", "--type", "vector"])
+    result = runner.invoke(list, ["test", "--type", type])
     mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&type=vector"
-    )
-    assert result.exit_code == 0
-    assert result.output == """test.tileset-1\ntest.tileset-2\n"""
-
-
-@pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.Session.get")
-def test_cli_list_type_raster(mock_request_get, MockResponse):
-    runner = CliRunner()
-
-    message = [
-        {"id": "test.tileset-1", "something": "beep"},
-        {"id": "test.tileset-2", "something": "boop"},
-    ]
-
-    mock_request_get.return_value = MockResponse(message)
-    result = runner.invoke(list, ["test", "--type", "raster"])
-    mock_request_get.assert_called_with(
-        "https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&type=raster"
+        f"https://api.mapbox.com/tilesets/v1/test?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K&limit=100&type={type}"
     )
     assert result.exit_code == 0
     assert result.output == """test.tileset-1\ntest.tileset-2\n"""


### PR DESCRIPTION
## changes
* adds `rasterarray` as an allowed type on the `list` command.
* changes the type test to use `pytest.mark.parametrize` and tests against the supported types.