### PR TITLE
Suport raster data upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ target/
 
 # OS X
 .DS_Store
+
+# tmp
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.11.0 (2024-07-30)
+- Add support for raster data upload with the `upload-source` command.
+
 # 1.10.0 (2024-05-07)
 - Add support for the `rasterarray` type on the `list` command.
 

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/tests/test_cli_sources.py
+++ b/tests/test_cli_sources.py
@@ -1,125 +1,19 @@
-from click.testing import CliRunner
 import json
 import os
-import click
 from unittest import mock
 
+import click
 import pytest
-
-from mapbox_tilesets.scripts.cli import (
-    add_source,
-    upload_source,
-    view_source,
-    delete_source,
-    validate_source,
-    list_sources,
-)
+from click.testing import CliRunner
 from utils import clean_runner_output
 
-
-@pytest.mark.usefixtures("token_environ")
-@mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoder")
-@mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoderMonitor")
-@mock.patch("requests.Session.post")
-def test_cli_add_source(
-    mock_request_post,
-    mock_multipart_encoder_monitor,
-    mock_multipart_encoder,
-    MockResponse,
-    MockMultipartEncoding,
-):
-    okay_response = {"id": "mapbox://tileset-source/test-user/hello-world"}
-    mock_request_post.return_value = MockResponse(okay_response, status_code=200)
-
-    expected_json = b'{"type":"Feature","geometry":{"type":"Point","coordinates":[125.6,10.1]},"properties":{"name":"Dinagat Islands"}}\n'
-
-    def side_effect(fields):
-        assert fields["file"][1].read() == expected_json
-        return MockMultipartEncoding()
-
-    mock_multipart_encoder.side_effect = side_effect
-
-    runner = CliRunner()
-    validated_result = runner.invoke(
-        add_source, ["test-user", "hello-world", "tests/fixtures/valid.ldgeojson"]
-    )
-    assert validated_result.exit_code == 0
-    assert (
-        validated_result.output
-        == """upload progress\n{"id": "mapbox://tileset-source/test-user/hello-world"}\n"""
-    )
-
-
-@pytest.mark.usefixtures("token_environ")
-@mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoder")
-@mock.patch("mapbox_tilesets.scripts.cli.MultipartEncoderMonitor")
-@mock.patch("requests.Session.post")
-def test_cli_add_source_wrong_username(
-    mock_request_post,
-    mock_multipart_encoder_monitor,
-    mock_multipart_encoder,
-    MockResponse,
-    MockMultipartEncoding,
-):
-    if "MAPBOX_ACCESS_TOKEN" in os.environ:
-        del os.environ["MAPBOX_ACCESS_TOKEN"]
-
-    # This is the base64 encoding of '{"u":"wrong-user"}', not a real token
-    os.environ["MapboxAccessToken"] = "pk.eyJ1Ijoid3JvbmctdXNlciJ9Cg.xxx"
-
-    runner = CliRunner()
-    validated_result = runner.invoke(
-        add_source, ["test-user-wrong", "hello-world", "tests/fixtures/valid.ldgeojson"]
-    )
-    assert validated_result.exit_code == 1
-
-    assert (
-        clean_runner_output(validated_result.output)
-        == "Token username wrong-user does not match username test-user-wrong"
-    )
-
-
-def test_cli_add_source_no_token():
-    if "MAPBOX_ACCESS_TOKEN" in os.environ:
-        del os.environ["MAPBOX_ACCESS_TOKEN"]
-    if "MapboxAccessToken" in os.environ:
-        del os.environ["MapboxAccessToken"]
-
-    runner = CliRunner()
-    unauthenticated_result = runner.invoke(
-        add_source, ["test-user", "hello-world", "tests/fixtures/valid.ldgeojson"]
-    )
-    assert unauthenticated_result.exit_code == 1
-
-    assert (
-        clean_runner_output(unauthenticated_result.output)
-        == """No access token provided. Please set the MAPBOX_ACCESS_TOKEN environment variable or use the --token flag."""
-    )
-
-
-@pytest.mark.usefixtures("token_environ")
-@mock.patch("requests.Session.post")
-def test_cli_add_source_no_validation(mock_request_post, MockResponse):
-    error_response = {
-        "message": "Invalid file format. Only GeoJSON features are allowed."
-    }
-    mock_request_post.return_value = MockResponse(error_response, status_code=400)
-    runner = CliRunner()
-    no_validation_result = runner.invoke(
-        add_source,
-        [
-            "test-user",
-            "hello-again",
-            "tests/fixtures/invalid.ldgeojson",
-            "--no-validation",
-        ],
-    )
-    assert no_validation_result.exit_code == 1
-
-    assert (
-        clean_runner_output(no_validation_result.output)
-        == '{"message": "Invalid file format. Only GeoJSON features are allowed."}'
-    )
+from mapbox_tilesets.scripts.cli import (
+    delete_source,
+    list_sources,
+    upload_source,
+    validate_source,
+    view_source,
+)
 
 
 @pytest.mark.usefixtures("token_environ")


### PR DESCRIPTION
Changes
- Add support to upload raster source supported by MTS
- Remove use of "cligj" to accept input 
- Skip validation of source in CLI, but rather rely on API response. 