### PR TITLE
Nickgerancher/cu estimation testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.12.0 (2024-10-23)
+- Added command `tilesets estimate-cu` that returns an estimated compute unit value for a user's tileset.
+
 # 1.11.1 (2024-08-01)
 - Added command `tilesets upload-raster-source` to upload raster files as sources
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,9 @@ tilesets delete-source user source_id
 tilesets estimate-cu <tileset> -s/--sources <sources> -b/--num-bands <number> --raw
 ```
 
-Estimates the CU value of a tileset before publishing it. This is useful to understand the estimated cost a given tileset before you start processing the data. Note: This is currently only available to tileset recipes with type `raster` and `rasterarray`.
+Estimates the CU value of a tileset before publishing it. This is useful to understand the estimated cost a given tileset before you start processing the data. Note: This is currently only available to tileset recipes with type `raster` or `rasterarray`.
+
+See https://docs.mapbox.com/help/glossary/compute-unit/ for more information.
 
 Flags:
 - `-s` or `--sources` [optional]: Local path to the sources that your recipe points at. This is highly recommeneded.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ export MAPBOX_ACCESS_TOKEN=my.token
   - [`list-sources`](#list-sources)
   - [`delete-source`](#delete-source)
   - [`estimate-area`](#estimate-area)
+  - [`estimate-cu`](#estimate-cu)
 - Recipes
   - [`view-recipe`](#view-recipe)
   - [`validate-recipe`](#validate-recipe)
@@ -220,6 +221,29 @@ Usage
 ```shell
 # to delete mapbox://tileset-source/user/source_id
 tilesets delete-source user source_id
+```
+
+### estimate-cu
+
+```shell
+tilesets estimate-cu <tileset> -s/--sources <sources> -b/--num-bands <number> --raw
+```
+
+Estimates the CU value of a tileset before publishing it. This is useful to understand the estimated cost a given tileset before you start processing the data. Note: This is currently only available to tileset recipes with type `raster` and `rasterarray`.
+
+Flags:
+- `-s` or `--sources` [optional]: Local path to the sources that your recipe points at. This is highly recommeneded.
+- `-b` or `--num-bands` [optional]: The number of bands you expect your recipe to select across all layers. This is recommended.
+- `--raw` [optional]: This will toggle the pretty print output.
+
+Usage
+
+```shell
+# Estimate the CUs for 'account.tileset' with sources located in 'path/to/sources/' and a band count of 20.
+tilesets estimate-cu account.tileset -s 'path/to/sources/*.grib2' -b 20
+
+# Estimate the CUs for 'account.tileset' for a single source and a band count of 10 (pretty print the results)
+tilesets estimate-cu account.tileset -s 'path/to/sources/helloworld.grib2' -b 10 --raw
 ```
 
 ### estimate-area

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ See https://docs.mapbox.com/help/glossary/compute-unit/ for more information.
 Flags:
 - `-s` or `--sources` [optional]: Local path to the sources that your recipe points at. This is highly recommeneded.
 - `-b` or `--num-bands` [optional]: The number of bands you expect your recipe to select across all layers. This is recommended.
+- `--minzoom` [optional]: Use this flag if your recipe does not contain a minzoom value.
+- `--maxzoom` [optional]: Use this flag if your recipe does not contain a maxzoom value.
 - `--raw` [optional]: This will toggle the pretty print output.
 
 Usage

--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ Note, Windows is not officially supported at this time.
 Windows users need to install [GDAL](http://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal) and [rasterio](http://www.lfd.uci.edu/~gohlke/pythonlibs/#rasterio).
 Then `pip install 'mapbox-tilesets[estimate-area]'`
 
+## Installing optional `estimate-cu` command
+
+If you are using an x86 Mac or Linux machine, run:
+`pip install 'mapbox-tilesets[estimate-cu]'`
+
+Otherwise, you will need to install some dependencies.
+
+### arm64 MacOS
+
+If you're on an arm64 Mac (e.g., with an M1 chip), you'll need to install [GDAL](https://gdal.org/) first. On Mac, a simple way is to use [Homebrew](https://brew.sh/):
+
+```sh
+$ brew install gdal
+...
+$ pip install 'mapbox-tilesets[estimate-cu]'
+```
+
+### Windows
+
+Note, Windows is not officially supported at this time.
+
+Windows users need to install [GDAL](http://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal) and [rasterio](http://www.lfd.uci.edu/~gohlke/pythonlibs/#rasterio).
+Then `pip install 'mapbox-tilesets[estimate-cu]'`
+
 ## Mapbox Access Tokens
 
 In order to use the tilesets endpoints, you need a Mapbox Access Token with `tilesets:write`, `tilesets:read`, and `tilesets:list` scopes. This is a secret token, so do not share it publicly!

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.11.1"
+__version__ = "1.12.0"

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -859,23 +859,21 @@ def validate_stream(features):
     default=15,
     help="The number of bands your recipe is selecting",
 )
-@click.option(
-    "--minzoom",
-    required=False,
-    type=int,
-    help="The minzoom value override"
-)
-@click.option(
-    "--maxzoom",
-    required=False,
-    type=int,
-    help="The maxzoom value override"
-)
+@click.option("--minzoom", required=False, type=int, help="The minzoom value override")
+@click.option("--maxzoom", required=False, type=int, help="The maxzoom value override")
 @click.option(
     "--raw", required=False, type=bool, default=False, is_flag=True, help="Raw CU value"
 )
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
-def estimate_cu(tileset, num_bands=15, minzoom=None, maxzoom=None, sources=None, raw=False, token=None):
+def estimate_cu(
+    tileset,
+    num_bands=15,
+    minzoom=None,
+    maxzoom=None,
+    sources=None,
+    raw=False,
+    token=None,
+):
     """
     Estimates the CUs that will be consumed when processing your recipe into a tileset.
     Requires extra installation steps: see https://github.com/mapbox/tilesets-cli/blob/master/README.md

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -842,12 +842,12 @@ def validate_stream(features):
 
 
 @cli.command("estimate-cu")
-@click.option("--tileset", "-i", required=True, type=str, help="Tileset ID to estimate")
+@click.argument("tileset", required=True, type=str)
 @click.option(
     "--sources",
     "-s",
     required=False,
-    type=str,
+    type=click.Path(exists=False),
     help="Local sources represented in your tileset's recipe",
 )
 @click.option(
@@ -870,7 +870,7 @@ def estimate_cu(tileset, num_bands=15, sources=None, raw=False, token=None):
 
     rio = utils.load_module("rasterio")
 
-    if not sources or len(sources) <= 0:
+    if sources is None:
         click.echo(f"[warning] estimating '{tileset}' with a default global bounds")
         sources = ""
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -842,19 +842,13 @@ def validate_stream(features):
 
 
 @cli.command("estimate-cu")
-@click.option(
-    "--tileset", 
-    "-i",
-    required=True,
-    type=str,
-    help="Tileset ID to estimate"
-)
+@click.option("--tileset", "-i", required=True, type=str, help="Tileset ID to estimate")
 @click.option(
     "--sources",
     "-s",
     required=False,
     type=str,
-    help="Local sources represented in your tileset's recipe"
+    help="Local sources represented in your tileset's recipe",
 )
 @click.option(
     "--num-bands",
@@ -862,13 +856,15 @@ def validate_stream(features):
     required=False,
     type=int,
     default=15,
-    help="The number of bands your recipe is selecting"
+    help="The number of bands your recipe is selecting",
 )
-@click.option("--raw", required=False, type=bool, default=False, is_flag=True, help="Raw CU value")
+@click.option(
+    "--raw", required=False, type=bool, default=False, is_flag=True, help="Raw CU value"
+)
 @click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
 def estimate_cu(tileset, num_bands=15, sources=None, raw=False, token=None):
     """
-    Estimates the CUs that will be consumed when processing your recipe into a tileset. 
+    Estimates the CUs that will be consumed when processing your recipe into a tileset.
     Requires extra installation steps: see https://github.com/mapbox/tilesets-cli/blob/master/README.md
     """
 
@@ -903,9 +899,7 @@ def estimate_cu(tileset, num_bands=15, sources=None, raw=False, token=None):
     s = utils._get_session()
     mapbox_api = utils._get_api()
     mapbox_token = utils._get_token(token)
-    url = "{0}/tilesets/v1/{1}/estimate".format(
-        mapbox_api, tileset
-    )
+    url = "{0}/tilesets/v1/{1}/estimate".format(mapbox_api, tileset)
 
     query_params = {
         "band_count": num_bands,
@@ -919,13 +913,15 @@ def estimate_cu(tileset, num_bands=15, sources=None, raw=False, token=None):
 
     if not response.ok:
         raise errors.TilesetsError(response.text)
-    
+
     parsed = json.loads(response.text)
-    if 'cu' not in parsed:
+    if "cu" not in parsed:
         raise errors.TilesetsError(response.text)
-    
+
     click.echo(
-        response.text if raw else f"\nEstimated CUs for '{tileset}': {parsed['cu']}. To publish your tileset, run 'tilesets publish'."
+        response.text
+        if raw
+        else f"\nEstimated CUs for '{tileset}': {click.style(parsed['cu'], bold=True, fg=155)}. To publish your tileset, run 'tilesets publish'."
     )
 
 

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -843,54 +843,51 @@ def validate_stream(features):
 
 @cli.command("estimate-cu")
 @click.option(
-    "--recipe", 
-    "-r",
+    "--tileset", 
+    "-i",
     required=True,
-    type=click.Path(exists=True),
-    help="Path to a raster recipe"
+    type=str,
+    help="Tileset ID to estimate"
 )
 @click.option(
     "--sources",
     "-s",
     required=False,
-    type=click.Path(exists=True)
+    type=str,
+    help="Local sources represented in your tileset's recipe"
 )
-def estimate_cu(recipe, sources=None):
+@click.option(
+    "--num-bands",
+    "-b",
+    required=False,
+    type=int,
+    default=15,
+    help="The number of bands your recipe is selecting"
+)
+@click.option("--raw", required=False, type=bool, default=False, is_flag=True, help="Raw CU value")
+@click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
+def estimate_cu(tileset, num_bands=15, sources=None, raw=False, token=None):
     """
     Estimates the CUs that will be consumed when processing your recipe into a tileset. 
     Requires extra installation steps: see https://github.com/mapbox/tilesets-cli/blob/master/README.md
     """
 
     rio = utils.load_module("rasterio")
-    cu = utils.load_module("estimator")
 
-    with open(recipe, mode="r") as f:
-        recipe_data = json.load(f)
-        if "recipe" in recipe_data:
-            recipe_data = recipe_data["recipe"]
+    if not sources or len(sources) <= 0:
+        click.echo(f"[warning] estimating '{tileset}' with a default global bounds")
+        sources = ""
 
-        if recipe_data["type"] not in ["raster", "rasterarray"]:
-            raise ValueError("only raster recipes can be estimated")
-        
-        estimator = cu.CUEstimator(recipe=recipe)
+    overall_bounds = None
+    src_list = glob(sources)
 
-        if sources is None:
-            recipe_sources = recipe_data.get("sources")
-            if recipe_sources is None:
-                raise ValueError("a raster recipe must contain sources")
-            
-            sources = [s["uri"] for s in recipe_sources]
-        else:
-            sources = glob(sources)
-
-        if not sources or len(sources) <= 0:
-            raise ValueError("at least 1 source file is required")
-
-        with rio.open(sources[0], mode="r") as ds:
+    if len(src_list) > 0:
+        with rio.open(src_list[0], mode="r") as ds:
             overall_bounds = ds.bounds
 
-        if len(sources) > 1:
-            for source in sources:
+    if len(src_list) > 1:
+        for source in src_list:
+            try:
                 with rio.open(source, mode="r") as ds:
                     if ds.bounds.left < overall_bounds.left:
                         overall_bounds.left = ds.bounds.left
@@ -900,16 +897,36 @@ def estimate_cu(recipe, sources=None):
                         overall_bounds.top = ds.bounds.top
                     if ds.bounds.bottom < overall_bounds.bottom:
                         overall_bounds.bottom = ds.bounds.bottom
+            except Exception:
+                click.echo(f"[warning] skipping invalid source '{source}'")
 
-        result = estimator.features(
-            bounds=overall_bounds,
-            band_count=1
-        )
+    s = utils._get_session()
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    url = "{0}/tilesets/v1/{1}/estimate".format(
+        mapbox_api, tileset
+    )
 
-        click.echo(json.dumps({
-            "cu": result,
-        }))
+    query_params = {
+        "band_count": num_bands,
+        "access_token": mapbox_token,
+    }
 
+    if overall_bounds is not None:
+        query_params["bounds"] = json.dumps([*overall_bounds])
+
+    response = s.get(url, params=query_params)
+
+    if not response.ok:
+        raise errors.TilesetsError(response.text)
+    
+    parsed = json.loads(response.text)
+    if 'cu' not in parsed:
+        raise errors.TilesetsError(response.text)
+    
+    click.echo(
+        response.text if raw else f"\nEstimated CUs for '{tileset}': {parsed['cu']}. To publish your tileset, run 'tilesets publish'."
+    )
 
 
 @cli.command("estimate-area")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.23.10
 Click==8.0.2
 cligj==0.7.2
-numpy==2.0.2
+numpy==1.19.5
 requests==2.27.1
 requests-toolbelt==0.9.1
 jsonschema==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.23.10
 Click==8.0.2
 cligj==0.7.2
-numpy==1.19.5
+numpy==2.0.2
 requests==2.27.1
 requests-toolbelt==0.9.1
 jsonschema==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         ],
         "estimate-cu": [
             "rasterio~=1.4.1",
-            "cu_model==0.0.1-dev3",
+            "cu_model==0.0.1-dev6",
         ],
         "test": [
             "codecov",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         ],
         "estimate-cu": [
             "rasterio~=1.4.1",
-            "cu_model==0.0.1-dev6",
         ],
         "test": [
             "codecov",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,10 @@ setup(
         "estimate-area": [
             "supermercado~=0.2.0",
         ],
+        "estimate-cu": [
+            "rasterio~=1.4.1",
+            "cu_model==0.0.1-dev3",
+        ],
         "test": [
             "codecov",
             "pytest==6.2.5",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,17 @@ def token_environ(monkeypatch):
     monkeypatch.setenv("MAPBOX_ACCESS_TOKEN", "pk.eyJ1IjoidGVzdC11c2VyIn0K")
     monkeypatch.setenv("MapboxAccessToken", "test-token")
 
+@pytest.fixture(scope="function")
+def api_environ(monkeypatch):
+    monkeypatch.setenv("MAPBOX_API", "https://api.mapbox.com")
+
 
 class _MockResponse:
     def __init__(self, mock_json, status_code=200):
         self.text = json.dumps(mock_json)
         self._json = mock_json
         self.status_code = status_code
+        self.ok = status_code < 400
 
     def MockResponse(self):
         return self

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def token_environ(monkeypatch):
     monkeypatch.setenv("MAPBOX_ACCESS_TOKEN", "pk.eyJ1IjoidGVzdC11c2VyIn0K")
     monkeypatch.setenv("MapboxAccessToken", "test-token")
 
+
 @pytest.fixture(scope="function")
 def api_environ(monkeypatch):
     monkeypatch.setenv("MAPBOX_API", "https://api.mapbox.com")

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -1,0 +1,49 @@
+import json
+import pytest
+from unittest import mock
+
+from click.testing import CliRunner
+
+from mapbox_tilesets.scripts.cli import estimate_cu
+from utils import clean_runner_output
+
+@pytest.mark.usefixtures("token_environ")
+@pytest.mark.usefixtures("api_environ")
+@mock.patch("requests.Session.get")
+def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
+    runner = CliRunner()
+    
+    tileset_id = "my.tileset"
+    msg = {"message": "mock message"}
+
+    mock_request_get.return_value = MockResponse(msg)
+    result = runner.invoke(estimate_cu, [tileset_id])
+    mock_request_get.assert_called_with(
+        f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
+        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"}
+    )
+
+    assert result.exit_code == 1
+    assert result.output == f"[warning] estimating '{tileset_id}' with a default global bounds\nError: {json.dumps(msg)}\n"
+
+
+@pytest.mark.usefixtures("token_environ")
+@pytest.mark.usefixtures("api_environ")
+@mock.patch("requests.Session.get")
+@mock.patch("glob.glob")
+def test_cli_estimate_cu_tilese_with_sources(mock_glob, mock_request_get, MockResponse):
+    runner = CliRunner()
+    
+    tileset_id = "my.tileset"
+    msg = {"cu": "5"}
+
+    mock_request_get.return_value = MockResponse(msg)
+    mock_glob.return_value = ["myfile.grib2"]
+    result = runner.invoke(estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2", "--raw"])
+    mock_request_get.assert_called_with(
+        f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
+        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"}
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == msg

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -5,14 +5,14 @@ from unittest import mock
 from click.testing import CliRunner
 
 from mapbox_tilesets.scripts.cli import estimate_cu
-from utils import clean_runner_output
+
 
 @pytest.mark.usefixtures("token_environ")
 @pytest.mark.usefixtures("api_environ")
 @mock.patch("requests.Session.get")
 def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
     runner = CliRunner()
-    
+
     tileset_id = "my.tileset"
     msg = {"message": "mock message"}
 
@@ -20,11 +20,14 @@ def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
     result = runner.invoke(estimate_cu, [tileset_id])
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
-        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"}
+        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
     )
 
     assert result.exit_code == 1
-    assert result.output == f"[warning] estimating '{tileset_id}' with a default global bounds\nError: {json.dumps(msg)}\n"
+    assert (
+        result.output
+        == f"[warning] estimating '{tileset_id}' with a default global bounds\nError: {json.dumps(msg)}\n"
+    )
 
 
 @pytest.mark.usefixtures("token_environ")
@@ -33,16 +36,18 @@ def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
 @mock.patch("glob.glob")
 def test_cli_estimate_cu_tilese_with_sources(mock_glob, mock_request_get, MockResponse):
     runner = CliRunner()
-    
+
     tileset_id = "my.tileset"
     msg = {"cu": "5"}
 
     mock_request_get.return_value = MockResponse(msg)
     mock_glob.return_value = ["myfile.grib2"]
-    result = runner.invoke(estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2", "--raw"])
+    result = runner.invoke(
+        estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2", "--raw"]
+    )
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
-        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"}
+        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
     )
 
     assert result.exit_code == 0

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -20,7 +20,7 @@ def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
     result = runner.invoke(estimate_cu, [tileset_id])
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
-        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
+        params={"filesize": 0, "band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
     )
 
     assert result.exit_code == 1
@@ -49,7 +49,7 @@ def test_cli_estimate_cu_tileset_with_sources_raw(
     )
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
-        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
+        params={"filesize": 0, "band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
     )
 
     assert result.exit_code == 0
@@ -73,7 +73,7 @@ def test_cli_estimate_cu_tileset_with_sources(
     result = runner.invoke(estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2"])
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
-        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
+        params={"filesize": 0, "band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
     )
 
     assert result.exit_code == 0

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -94,6 +94,7 @@ def test_cli_estimate_cu_tileset_with_sources(
         == f"\nEstimated CUs for '{tileset_id}': {msg['cu']}. To publish your tileset, run 'tilesets publish'.\n"
     )
 
+
 @pytest.mark.usefixtures("token_environ")
 @pytest.mark.usefixtures("api_environ")
 @mock.patch("requests.Session.get")
@@ -108,7 +109,10 @@ def test_cli_estimate_cu_tileset_with_zoom_overrides(
 
     mock_request_get.return_value = MockResponse(msg)
     mock_glob.return_value = ["myfile.grib2"]
-    result = runner.invoke(estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2", "--minzoom", 1, "--maxzoom", 6])
+    result = runner.invoke(
+        estimate_cu,
+        [tileset_id, "-s", "/my/sources/*.grib2", "--minzoom", 1, "--maxzoom", 6],
+    )
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
         params={

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -34,7 +34,7 @@ def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
 @pytest.mark.usefixtures("api_environ")
 @mock.patch("requests.Session.get")
 @mock.patch("glob.glob")
-def test_cli_estimate_cu_tilese_with_sources_raw(
+def test_cli_estimate_cu_tileset_with_sources_raw(
     mock_glob, mock_request_get, MockResponse
 ):
     runner = CliRunner()
@@ -60,7 +60,9 @@ def test_cli_estimate_cu_tilese_with_sources_raw(
 @pytest.mark.usefixtures("api_environ")
 @mock.patch("requests.Session.get")
 @mock.patch("glob.glob")
-def test_cli_estimate_cu_tilese_with_sources(mock_glob, mock_request_get, MockResponse):
+def test_cli_estimate_cu_tileset_with_sources(
+    mock_glob, mock_request_get, MockResponse
+):
     runner = CliRunner()
 
     tileset_id = "my.tileset"

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -34,7 +34,9 @@ def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
 @pytest.mark.usefixtures("api_environ")
 @mock.patch("requests.Session.get")
 @mock.patch("glob.glob")
-def test_cli_estimate_cu_tilese_with_sources_raw(mock_glob, mock_request_get, MockResponse):
+def test_cli_estimate_cu_tilese_with_sources_raw(
+    mock_glob, mock_request_get, MockResponse
+):
     runner = CliRunner()
 
     tileset_id = "my.tileset"
@@ -66,13 +68,14 @@ def test_cli_estimate_cu_tilese_with_sources(mock_glob, mock_request_get, MockRe
 
     mock_request_get.return_value = MockResponse(msg)
     mock_glob.return_value = ["myfile.grib2"]
-    result = runner.invoke(
-        estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2"]
-    )
+    result = runner.invoke(estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2"])
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
         params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
     )
 
     assert result.exit_code == 0
-    assert result.output == f"\nEstimated CUs for '{tileset_id}': {msg['cu']}. To publish your tileset, run 'tilesets publish'.\n"
+    assert (
+        result.output
+        == f"\nEstimated CUs for '{tileset_id}': {msg['cu']}. To publish your tileset, run 'tilesets publish'.\n"
+    )

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -34,7 +34,7 @@ def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
 @pytest.mark.usefixtures("api_environ")
 @mock.patch("requests.Session.get")
 @mock.patch("glob.glob")
-def test_cli_estimate_cu_tilese_with_sources(mock_glob, mock_request_get, MockResponse):
+def test_cli_estimate_cu_tilese_with_sources_raw(mock_glob, mock_request_get, MockResponse):
     runner = CliRunner()
 
     tileset_id = "my.tileset"
@@ -52,3 +52,27 @@ def test_cli_estimate_cu_tilese_with_sources(mock_glob, mock_request_get, MockRe
 
     assert result.exit_code == 0
     assert json.loads(result.output) == msg
+
+
+@pytest.mark.usefixtures("token_environ")
+@pytest.mark.usefixtures("api_environ")
+@mock.patch("requests.Session.get")
+@mock.patch("glob.glob")
+def test_cli_estimate_cu_tilese_with_sources(mock_glob, mock_request_get, MockResponse):
+    runner = CliRunner()
+
+    tileset_id = "my.tileset"
+    msg = {"cu": "5"}
+
+    mock_request_get.return_value = MockResponse(msg)
+    mock_glob.return_value = ["myfile.grib2"]
+    result = runner.invoke(
+        estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2"]
+    )
+    mock_request_get.assert_called_with(
+        f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
+        params={"band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
+    )
+
+    assert result.exit_code == 0
+    assert result.output == f"\nEstimated CUs for '{tileset_id}': {msg['cu']}. To publish your tileset, run 'tilesets publish'.\n"

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -93,3 +93,35 @@ def test_cli_estimate_cu_tileset_with_sources(
         result.output
         == f"\nEstimated CUs for '{tileset_id}': {msg['cu']}. To publish your tileset, run 'tilesets publish'.\n"
     )
+
+@pytest.mark.usefixtures("token_environ")
+@pytest.mark.usefixtures("api_environ")
+@mock.patch("requests.Session.get")
+@mock.patch("glob.glob")
+def test_cli_estimate_cu_tileset_with_zoom_overrides(
+    mock_glob, mock_request_get, MockResponse
+):
+    runner = CliRunner()
+
+    tileset_id = "my.tileset"
+    msg = {"cu": "5"}
+
+    mock_request_get.return_value = MockResponse(msg)
+    mock_glob.return_value = ["myfile.grib2"]
+    result = runner.invoke(estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2", "--minzoom", 1, "--maxzoom", 6])
+    mock_request_get.assert_called_with(
+        f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
+        params={
+            "minzoom": 1,
+            "maxzoom": 6,
+            "filesize": 0,
+            "band_count": 15,
+            "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K",
+        },
+    )
+
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == f"\nEstimated CUs for '{tileset_id}': {msg['cu']}. To publish your tileset, run 'tilesets publish'.\n"
+    )

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -129,3 +129,49 @@ def test_cli_estimate_cu_tileset_with_zoom_overrides(
         result.output
         == f"\nEstimated CUs for '{tileset_id}': {msg['cu']}. To publish your tileset, run 'tilesets publish'.\n"
     )
+
+
+@pytest.mark.usefixtures("token_environ")
+@pytest.mark.usefixtures("api_environ")
+@mock.patch("requests.Session.get")
+@mock.patch("glob.glob")
+def test_cli_estimate_cu_tileset_with_bands_override(
+    mock_glob, mock_request_get, MockResponse
+):
+    runner = CliRunner()
+
+    tileset_id = "my.tileset"
+    msg = {"cu": "5"}
+
+    mock_request_get.return_value = MockResponse(msg)
+    mock_glob.return_value = ["myfile.grib2"]
+    result = runner.invoke(
+        estimate_cu,
+        [
+            tileset_id,
+            "-s",
+            "/my/sources/*.grib2",
+            "-b",
+            10,
+            "--minzoom",
+            1,
+            "--maxzoom",
+            6,
+        ],
+    )
+    mock_request_get.assert_called_with(
+        f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
+        params={
+            "minzoom": 1,
+            "maxzoom": 6,
+            "filesize": 0,
+            "band_count": 10,
+            "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K",
+        },
+    )
+
+    assert result.exit_code == 0
+    assert (
+        result.output
+        == f"\nEstimated CUs for '{tileset_id}': {msg['cu']}. To publish your tileset, run 'tilesets publish'.\n"
+    )

--- a/tests/test_cli_estimate_cu.py
+++ b/tests/test_cli_estimate_cu.py
@@ -20,7 +20,11 @@ def test_cli_estimate_cu_tileset_no_sources(mock_request_get, MockResponse):
     result = runner.invoke(estimate_cu, [tileset_id])
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
-        params={"filesize": 0, "band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
+        params={
+            "filesize": 0,
+            "band_count": 15,
+            "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K",
+        },
     )
 
     assert result.exit_code == 1
@@ -49,7 +53,11 @@ def test_cli_estimate_cu_tileset_with_sources_raw(
     )
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
-        params={"filesize": 0, "band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
+        params={
+            "filesize": 0,
+            "band_count": 15,
+            "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K",
+        },
     )
 
     assert result.exit_code == 0
@@ -73,7 +81,11 @@ def test_cli_estimate_cu_tileset_with_sources(
     result = runner.invoke(estimate_cu, [tileset_id, "-s", "/my/sources/*.grib2"])
     mock_request_get.assert_called_with(
         f"https://api.mapbox.com/tilesets/v1/{tileset_id}/estimate",
-        params={"filesize": 0, "band_count": 15, "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K"},
+        params={
+            "filesize": 0,
+            "band_count": 15,
+            "access_token": "pk.eyJ1IjoidGVzdC11c2VyIn0K",
+        },
     )
 
     assert result.exit_code == 0


### PR DESCRIPTION
### Changes (v1.12.0)
These changes introduce a new command: `estimate-cu`. This command is responsible for estimating the CU value of a tileset that has been created but not yet published. This new command relies on a dependency (`rasterio`) that is not included in the base installation of `tilesets-cli`. There are instructions documented for how to install this extra dependency, similar to the `estimate-area` command already defined in `tilesets-cli`.

These changes are reliant on some internal API changes. Once those are in place, we should be able to release these changes publicly.

See https://github.com/mapbox/tilesets-cli/blob/ac2496771693deccae9e82dc009203381d167646/README.md for the updated `estimate-cu` docs.