### PR TITLE
Add publish-changesets command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,5 +15,6 @@ repos:
           # E501 let black handle all line length decisions
           # W503 black conflicts with "line break before operator" rule
           # E203 black conflicts with "whitespace before ':'" rule
+          # E231 black conflicts with "whitespace after ':'" rule
           # E722 bare excepts need to be addressed
-          '--ignore=E501,W503,E203,E722']
+          '--ignore=E501,W503,E203,E722,E231']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 =======
 
+# 1.14.0 (2025-01-12)
+- Added command `tilesets publish-changesets` that publishes changesets for a tileset.
+
 # 1.13.0 (2025-01-07)
 - Temporarily remove the `estimate-cu` command for further refinement.
 

--- a/README.md
+++ b/README.md
@@ -451,3 +451,12 @@ Flags:
 - `--limit [1-500]` [optional]: The maximum number of results to return (default: 100)
 - `--indent` [optional]: Indent size for JSON output.
 - `--start` [optional]: Pagination key from the `next` value in a response that has more results than the limit.
+
+
+### publish-changesets
+
+Publishes changesets for a tileset. This command only supports tilesets created with the [Mapbox Tiling Service](https://docs.mapbox.com/mapbox-tiling-service/overview/).
+
+```shell
+tilesets publish-changesets <tileset_id> --changeset /path/to/changeset.json
+```

--- a/mapbox_tilesets/__init__.py
+++ b/mapbox_tilesets/__init__.py
@@ -1,3 +1,3 @@
 """mapbox_tilesets package"""
 
-__version__ = "1.13.0"
+__version__ = "1.14.0"

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -981,3 +981,26 @@ def list_activity(
         click.echo(json.dumps(result, indent=indent))
     else:
         raise errors.TilesetsError(r.text)
+
+
+@cli.command("publish-changesets")
+@click.argument("tileset_id", required=True, type=str)
+@click.argument("changeset_payload", required=True, type=click.Path(exists=True))
+@click.option("--token", "-t", required=False, type=str, help="Mapbox access token")
+@click.option("--indent", type=int, default=None, help="Indent for JSON output")
+def publish_changesets(tileset_id, changeset_payload, token=None, indent=None):
+    """Publish changesets for a tileset.
+
+    tilesets publish-changesets <tileset_id> <path_to_changeset_payload>
+    """
+    mapbox_api = utils._get_api()
+    mapbox_token = utils._get_token(token)
+    s = utils._get_session()
+    url = "{0}/tilesets/v1/{1}/publish-changesets?access_token={2}".format(
+        mapbox_api, tileset_id, mapbox_token
+    )
+    with open(changeset_payload) as changeset_payload_content:
+        changeset_payload_json = json.load(changeset_payload_content)
+
+        r = s.post(url, json=changeset_payload_json)
+        click.echo(json.dumps(r.json(),indent=indent))

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -1003,4 +1003,4 @@ def publish_changesets(tileset_id, changeset_payload, token=None, indent=None):
         changeset_payload_json = json.load(changeset_payload_content)
 
         r = s.post(url, json=changeset_payload_json)
-        click.echo(json.dumps(r.json(),indent=indent))
+        click.echo(json.dumps(r.json(), indent=indent))

--- a/mapbox_tilesets/scripts/cli.py
+++ b/mapbox_tilesets/scripts/cli.py
@@ -1003,4 +1003,8 @@ def publish_changesets(tileset_id, changeset_payload, token=None, indent=None):
         changeset_payload_json = json.load(changeset_payload_content)
 
         r = s.post(url, json=changeset_payload_json)
-        click.echo(json.dumps(r.json(), indent=indent))
+        if r.status_code == 200:
+            response_msg = r.json()
+            click.echo(json.dumps(response_msg, indent=indent))
+        else:
+            raise errors.TilesetsError(r.text)

--- a/tests/fixtures/changeset-payload.json
+++ b/tests/fixtures/changeset-payload.json
@@ -1,0 +1,7 @@
+{
+  "layers": {
+    "trees": {
+      "changeset": "mapbox://tileset-changeset/test.id/test-changeset-id"
+    }
+  }
+}

--- a/tests/test_cli_publish_changesets.py
+++ b/tests/test_cli_publish_changesets.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 from mapbox_tilesets.scripts.cli import publish_changesets
 
+
 class MockResponse:
     def __init__(self, mock_json, status_code):
         self.text = json.dumps(mock_json)
@@ -28,7 +29,9 @@ def test_cli_publish_changesets(mock_request_post):
     mock_request_post.return_value = MockResponse(
         {"message": "mock message", "jobId": "1234fakejob"}, 200
     )
-    result = runner.invoke(publish_changesets, ["test.id", "tests/fixtures/changeset-payload.json"])
+    result = runner.invoke(
+        publish_changesets, ["test.id", "tests/fixtures/changeset-payload.json"]
+    )
     mock_request_post.assert_called_with(
         "https://api.mapbox.com/tilesets/v1/test.id/publish-changesets?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
         json={
@@ -41,7 +44,4 @@ def test_cli_publish_changesets(mock_request_post):
     )
     assert result.exit_code == 0
     print(result.output)
-    assert (
-        '{"message": "mock message", "jobId": "1234fakejob"}'
-        in result.output
-    )
+    assert '{"message": "mock message", "jobId": "1234fakejob"}' in result.output

--- a/tests/test_cli_publish_changesets.py
+++ b/tests/test_cli_publish_changesets.py
@@ -1,0 +1,47 @@
+import json
+import pytest
+
+from click.testing import CliRunner
+from unittest import mock
+
+from mapbox_tilesets.scripts.cli import publish_changesets
+
+class MockResponse:
+    def __init__(self, mock_json, status_code):
+        self.text = json.dumps(mock_json)
+        self._json = mock_json
+        self.status_code = status_code
+
+    def MockResponse(self):
+        return self
+
+    def json(self):
+        return self._json
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.post")
+def test_cli_publish_changesets(mock_request_post):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_post.return_value = MockResponse(
+        {"message": "mock message", "jobId": "1234fakejob"}, 200
+    )
+    result = runner.invoke(publish_changesets, ["test.id", "tests/fixtures/changeset-payload.json"])
+    mock_request_post.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id/publish-changesets?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
+        json={
+            "layers": {
+                "trees": {
+                    "changeset": "mapbox://tileset-changeset/test.id/test-changeset-id"
+                }
+            }
+        },
+    )
+    assert result.exit_code == 0
+    print(result.output)
+    assert (
+        '{"message": "mock message", "jobId": "1234fakejob"}'
+        in result.output
+    )

--- a/tests/test_cli_publish_changesets.py
+++ b/tests/test_cli_publish_changesets.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 from unittest import mock
 
 from mapbox_tilesets.scripts.cli import publish_changesets
+from utils import clean_runner_output
 
 
 class MockResponse:
@@ -22,7 +23,7 @@ class MockResponse:
 
 @pytest.mark.usefixtures("token_environ")
 @mock.patch("requests.Session.post")
-def test_cli_publish_changesets(mock_request_post):
+def test_cli_publish_changesets_successful(mock_request_post):
     runner = CliRunner()
 
     # sends expected request
@@ -45,3 +46,37 @@ def test_cli_publish_changesets(mock_request_post):
     assert result.exit_code == 0
     print(result.output)
     assert '{"message": "mock message", "jobId": "1234fakejob"}' in result.output
+
+
+@pytest.mark.usefixtures("token_environ")
+@mock.patch("requests.Session.post")
+def test_cli_publish_changesets_error(mock_request_post):
+    runner = CliRunner()
+
+    # sends expected request
+    mock_request_post.return_value = MockResponse(
+        {
+            "message": "Access Denied: Contact Mapbox Account Manager to enable MTS Incremental Update"
+        },
+        401,
+    )
+    result = runner.invoke(
+        publish_changesets, ["test.id", "tests/fixtures/changeset-payload.json"]
+    )
+    mock_request_post.assert_called_with(
+        "https://api.mapbox.com/tilesets/v1/test.id/publish-changesets?access_token=pk.eyJ1IjoidGVzdC11c2VyIn0K",
+        json={
+            "layers": {
+                "trees": {
+                    "changeset": "mapbox://tileset-changeset/test.id/test-changeset-id"
+                }
+            }
+        },
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+    print(result.output)
+    assert (
+        clean_runner_output(result.output)
+        == '{"message": "Access Denied: Contact Mapbox Account Manager to enable MTS Incremental Update"}'
+    )


### PR DESCRIPTION
# Details

- Added `publish-changesets` command to publish changesets for a tileset
- Updated CHANGELOG.md and README.md

To-do:

- [ ] git tag -a v1.14.0 -m 'v1.14.0' && git push --tags
- [ ] Confirm release at https://pypi.org/project/mapbox-tilesets/#history
