### PR TITLE
Added the delete changeset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ export MAPBOX_ACCESS_TOKEN=my.token
   - [`validate-source`](#validate-source)
   - [`view-source`](#view-source)
   - [`view-changeset`](#view-changeset)
+  - [`delete-changeset`](#delete-changeset)
   - [`list-sources`](#list-sources)
   - [`delete-source`](#delete-source)
   - [`estimate-area`](#estimate-area)
@@ -203,6 +204,25 @@ tilesets view-changeset <username> <changeset_id>
 ```
 
 Get information for a changeset, such as number of files, the size in bytes, and the ID in mapbox:// protocol format.
+
+### delete-changeset
+
+```
+tilesets delete-changeset <username> <changeset_id>
+```
+
+Permanently delete a changeset and all of its files. This is not a recoverable action!
+
+Flags:
+
+- `-f` or `--force`: Do not ask for confirmation before deleting
+
+Usage
+
+```shell
+# to delete mapbox://tileset-changeset/user/source_id
+tilesets delete-changeset user source_id
+```
 
 ### list-sources
 


### PR DESCRIPTION
### Context

This PR adds the functionality to delete a changeset and all of its files. The `delete-changeset` command follows the patterns used for the `delete-source` command.

### Tests

Manual tests:
<img width="840" alt="Screenshot 2025-02-17 at 11 32 40" src="https://github.com/user-attachments/assets/5cca63b1-26bc-4c9f-8d23-f33cc31bd43b" />

