### PR TITLE
Added the upload-changeset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ export MAPBOX_ACCESS_TOKEN=my.token
 - Tileset Sources
   - [`upload-source`](#upload-source)
   - [`upload-raster-source`](#upload-raster-source) (new)
+  - [`upload-changeset`](#upload-changeset)
   - _deprecated_ [`add-source`](#deprecated-add-source)
   - [`validate-source`](#validate-source)
   - [`view-source`](#view-source)
@@ -145,6 +146,23 @@ tilesets upload-raster-source <username> <source_id> ./file.tif
 # multiple files
 tilesets upload-raster-source <username> <source_id> file-1.tif file-4.tif
 ```
+### upload-chanegset
+
+```shell
+tilesets upload-changeset <username> <source_id> <file>
+```
+
+Uploads GeoJSON files to a changeset for tiling. Accepts line-delimited GeoJSON or GeoJSON feature collections as files or via `stdin`. The CLI automatically converts data to line-delimited GeoJSON prior to uploading. Can be used to add data to a source or to replace all of the data in a source with the `--replace` flag.
+
+Please note that if your source data is a FeatureCollection, `tilesets` must read it all into memory to split it up into separate features before uploading it to the Tilesets API. You are strongly encouraged to provide your data in line-delimited GeoJSON format instead, especially if it is large.
+
+Note: for large file uploads that are taking a very long time, try using the `--no-validation` flag.
+
+Flags:
+
+- `--no-validation` [optional]: do not validate source data locally before uploading, can be helpful for large file uploads
+- `--replace` [optional]: delete all existing source data and replace with data from the file
+- `--quiet` [optional]: do not display an upload progress bar
 
 ### _deprecated_ add-source
 

--- a/mapbox_tilesets/utils.py
+++ b/mapbox_tilesets/utils.py
@@ -82,7 +82,32 @@ def geojson_validate(index, feature):
         )
 
 
-def validate_geojson(index, feature):
+def validate_geojson(index, feature, allow_delete=False):
+
+    if allow_delete:
+        delete_schema = {
+            "definitions": {},
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "http://example.com/root.json",
+            "type": "object",
+            "title": "GeoJSON Delete Schema",
+            "required": ["delete"],
+            "properties": {
+                "delete": {
+                    "$id": "#/properties/delete",
+                    "const": True,
+                    "title": "The Delete Schema",
+                    "examples": [True],
+                },
+            },
+        }
+
+        try:
+            validate(instance=feature, schema=delete_schema)
+            return
+        except:
+            pass
+
     schema = {
         "definitions": {},
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -127,6 +152,7 @@ def validate_geojson(index, feature):
             },
         },
     }
+
     try:
         validate(instance=feature, schema=schema)
     except ValidationError as e:

--- a/tests/fixtures/invalid-changeset-geojson.ldgeojson
+++ b/tests/fixtures/invalid-changeset-geojson.ldgeojson
@@ -1,0 +1,2 @@
+{"id": 1, "delete": true, "type": "Feature", "geometry": { "type": "Point","coordinates": [125.6, 10.1]},"properties": {"name": "Dinagat Islands"}}
+{"id": 2, "delete": false}

--- a/tests/fixtures/valid-changeset.ldgeojson
+++ b/tests/fixtures/valid-changeset.ldgeojson
@@ -1,0 +1,3 @@
+{"id": 1, "type": "Feature", "geometry": { "type": "Point","coordinates": [125.6, 10.1]},"properties": {"name": "Dinagat Islands"}}
+{"id": 2, "type": "Feature", "geometry": { "type": "Point","coordinates": [-76.971938, 38.921387]},"properties": {"name": "ZELALEM INJERA"}}
+{"id": 3, "delete": true}


### PR DESCRIPTION
### Context

This PR adds the feature to upload / replace a changeset source. The switches are similar to uploading a new tileset source.

### Tests

Manual test, see on the screenshot
<img width="1150" alt="Screenshot 2025-02-17 at 16 48 56" src="https://github.com/user-attachments/assets/2ce21bd0-1b00-45fb-9fbe-46337d551b03" />
