### PR TITLE
Upgrade jsonschema to 4.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cligj==0.7.2
 numpy==1.19.5
 requests==2.27.1
 requests-toolbelt==0.9.1
-jsonschema==3.0.1
+jsonschema==4.25.1
 jsonseq==1.0.0
 mercantile==1.1.6
 supermercado==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 from codecs import open as codecs_open
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 from mapbox_tilesets import __version__
 
@@ -33,7 +34,7 @@ setup(
         "numpy",
         "requests",
         "requests-toolbelt",
-        "jsonschema~=3.0",
+        "jsonschema~=4.0",
         "jsonseq~=1.0",
         "mercantile~=1.1.6",
         "geojson~=2.5.0",


### PR DESCRIPTION
Hi!

We are happy users of tilesets-cli, thank you! However, the dependency on jsonschema~=3.0 recently has caused us some problems because our data pipeline tool, prefect, depends on 4.x.

Version 4 of jsonschema was released in 2022, but happily it doesn't look like the `validate` function you use has changed between versions. 

I've upgraded the version in requirements.txt and updated the pin in setup.py and it all seems to work fine for me.