### PR TITLE
Update release action

### DIFF
--- a/.github/actions/build-package/action.yaml
+++ b/.github/actions/build-package/action.yaml
@@ -4,7 +4,7 @@ inputs:
   python-version:
     description: 'Python version to use'
     required: false
-    default: '3.8'
+    default: '3.11'
 
 runs:
   using: "composite"
@@ -20,11 +20,11 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pip install twine wheel
+      run: pip install build twine wheel
       
     - name: Setup deployment
       shell: bash
-      run: python setup.py sdist bdist_wheel
+      run: python -m build --sdist --wheel
     
     - name: Validate deployment
       shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ jobs:
         - uses: actions/checkout@v4
 
         - uses: ./.github/actions/build-package
+          with:
+            python-version: '3.11'
 
         - name: Set up a fresh environment and run tests
           run: |
@@ -29,10 +31,10 @@ jobs:
         steps:
           - uses: actions/checkout@v4
           
-          - name: Set up Python 3.8
+          - name: Set up Python 3.11
             uses: actions/setup-python@v5
             with:
-              python-version: 3.8
+              python-version: '3.11'
 
           - name: Compare tags 
             run: |
@@ -41,6 +43,8 @@ jobs:
               [ "${{ github.ref_type }}" = "tag" ] && [ "${{ github.ref_name }}" = "v$PKG_VERSION" ]
 
           - uses: ./.github/actions/build-package
+            with:
+              python-version: '3.11'
     
           - name: Run deployment
             run: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,11 @@ dependencies = [
 
 [project.optional-dependencies]
 estimate-area = ["supermercado>=0.2.0"]
+test = [
+  "pre-commit>=3.5",
+  "pytest>=8",
+  "pytest-cov>=4",
+]
 
 [project.scripts]
 tilesets = "mapbox_tilesets.scripts.cli:cli"


### PR DESCRIPTION
This PR:

- Updates `action.yaml` to use `python -m build`, which is necessary now that we've moved from `setup.py` to `pyproject`.
- Bumps the Python version used in `action.yaml` to 3.11. (3.10 is the minimum we're supporting)
- Adds a `test` extra so that we can still `pip install -e .[test]`