### PR TITLE
Install estimate-area deps in release flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
             source venv/bin/activate
             pip install dist/*.tar.gz
             pip install dist/*.whl
-            pip install -e .[test]
+            pip install -e '.[test,estimate-area]'
             pytest
 
     release:


### PR DESCRIPTION
Missing the `supermercado` dependency in `release.yml` meant that the release action wouldn't [succeed](https://github.com/mapbox/tilesets-cli/actions/runs/20490629586/job/58882036802). Should have caught this earlier, but here am I again.