### PR TITLE
Check package version in pyproject.toml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
 
           - name: Compare tags 
             run: |
-              PKG_VERSION=`grep '__version__' mapbox_tilesets/__init__.py | sed -E "s/^.*['\"](.*)['\"].*$/\1/"`
+              PKG_VERSION=$(python -c "import pathlib, tomllib; data = tomllib.loads(pathlib.Path('pyproject.toml').read_text()); print(data['project']['version'])")
               echo "Checking that package version [v$PKG_VERSION] matches release tag [${{ github.ref_name }}]"
               [ "${{ github.ref_type }}" = "tag" ] && [ "${{ github.ref_name }}" = "v$PKG_VERSION" ]
 


### PR DESCRIPTION
Existing check in mapbox_tilesets/__init__.py is no longer appropriate.

This was [failing](https://github.com/mapbox/tilesets-cli/actions/runs/20760668922/job/59614555751) with errors like:

```
Run PKG_VERSION=`grep '__version__' mapbox_tilesets/__init__.py | sed -E "s/^.*['\"](.*)['\"].*$/\1/"`
Checking that package version [vmapbox-tilesets
0.0.0.dev] matches release tag [v2.0.0]
Error: Process completed with exit code 1.
```