### PR TITLE
Use uv-managed 3.11 install

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Compare tags 
         run: |
-          PKG_VERSION=$(python -c "import pathlib, tomllib; data = tomllib.loads(pathlib.Path('pyproject.toml').read_text()); print(data['project']['version'])")
+          PKG_VERSION=$(uv run python -c "import pathlib, tomllib; data = tomllib.loads(pathlib.Path('pyproject.toml').read_text()); print(data['project']['version'])")
           echo "Checking that package version [v$PKG_VERSION] matches release tag [${{ github.ref_name }}]"
           [ "${{ github.ref_type }}" = "tag" ] && [ "${{ github.ref_name }}" = "v$PKG_VERSION" ]
 


### PR DESCRIPTION
Addresses the failure seen in https://github.com/mapbox/tilesets-cli/actions/runs/20764686729

The Python version called is the system default, not uv-managed 3.11.